### PR TITLE
add basic conan recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake, tools
+
+
+class ConanRecipe(ConanFile):
+    name = "doctest"
+    version = "2.3.8"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_paths"
+    scm = {
+        "type": "git",
+        "url": "https://github.com/onqtam/doctest.git",
+        "revision": "auto"
+    }
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        cmake.test()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()


### PR DESCRIPTION
Added a basic conan recipe file. This both is a complete file but also WIP depending on what people need. Its been a while since I used conan so there likely exists obvious adjustsments that should be done.  

To install into conan cache, run 
```
conan create .
```
in doctest repo.

In the consumers conan recipe file add
```
build_requires = "doctest/2.3.8"
generators = "cmake_paths"
```
I prefer using cmake_paths generator as is fully decouples conan from cmake with the exception of the inclusion of the conan_paths.cmake file that appends to `CMAKE_MODULE_PATH` and `CMAKE_PREFIX_PATH`.

and in the cmake files of the consumer add
```
if(EXISTS ${CMAKE_BINARY_DIR}/conan_paths.cmake)
    include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
endif()
find_package(doctest)
include (doctest)
```
Then link against target doctest::doctest as normal.