### PR TITLE
Fix redefinition error while using double time DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -2050,7 +2050,8 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 // for logging
 #define DOCTEST_INFO(...)                                                                          \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),    \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
+                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
                       __VA_ARGS__)
 
 #define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -2047,7 +2047,8 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 // for logging
 #define DOCTEST_INFO(...)                                                                          \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),    \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
+                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
                       __VA_ARGS__)
 
 #define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \


### PR DESCRIPTION
## Description
Double `DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_)` leads to redefinition error on MSVS like this:
`error C2082: redefinition of formal parameter 'DOCTEST_CAPTURE_54'`
