### PR TITLE
Add -minimal flag

### DIFF
--- a/doc/markdown/commandline.md
+++ b/doc/markdown/commandline.md
@@ -43,6 +43,7 @@ All the options can also be set with code (defaults/overrides) if the user [**su
 | ```-cs``` &nbsp; ```--case-sensitive=<bool>``` | Filters being treated as case sensitive |
 | ```-e``` &nbsp;&nbsp;&nbsp; ```--exit=<bool>``` | Exits after the tests finish - this is meaningful only when the client has [**provided the ```main()``` entry point**](main.md)  - the program should check the ```shouldExit()``` method after calling ```run()``` on a ```doctest::Context``` object and should exit - this is left up to the user. The idea is to be able to execute just the tests in a client program and to not continue with it's execution |
 | ```-d``` &nbsp; ```--duration=<bool>``` | Prints the time each test case took in seconds |
+| ```-q``` &nbsp; ```--quiet=<bool>``` | Does not print any output |
 | ```-nt``` &nbsp; ```--no-throw=<bool>``` | Skips [**exceptions-related assertion**](assertions.md#exceptions) checks |
 | ```-ne``` &nbsp; ```--no-exitcode=<bool>``` | Always returns a successful exit code - even if a test case has failed |
 | ```-nr``` &nbsp; ```--no-run=<bool>``` | Skips all runtime **doctest** operations (except the test registering which happens before the program enters ```main()```). This is useful if the testing framework is integrated into a client codebase which has [**provided the ```main()``` entry point**](main.md) and the user wants to skip running the tests and just use the program |

--- a/doc/markdown/commandline.md
+++ b/doc/markdown/commandline.md
@@ -43,6 +43,7 @@ All the options can also be set with code (defaults/overrides) if the user [**su
 | ```-cs``` &nbsp; ```--case-sensitive=<bool>``` | Filters being treated as case sensitive |
 | ```-e``` &nbsp;&nbsp;&nbsp; ```--exit=<bool>``` | Exits after the tests finish - this is meaningful only when the client has [**provided the ```main()``` entry point**](main.md)  - the program should check the ```shouldExit()``` method after calling ```run()``` on a ```doctest::Context``` object and should exit - this is left up to the user. The idea is to be able to execute just the tests in a client program and to not continue with it's execution |
 | ```-d``` &nbsp; ```--duration=<bool>``` | Prints the time each test case took in seconds |
+| ```-m``` &nbsp; ```--minimal=<bool>``` | Only prints failing tests |
 | ```-q``` &nbsp; ```--quiet=<bool>``` | Does not print any output |
 | ```-nt``` &nbsp; ```--no-throw=<bool>``` | Skips [**exceptions-related assertion**](assertions.md#exceptions) checks |
 | ```-ne``` &nbsp; ```--no-exitcode=<bool>``` | Always returns a successful exit code - even if a test case has failed |

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -761,6 +761,7 @@ struct ContextOptions //!OCLINT too many fields
     bool case_sensitive;       // if filtering should be case sensitive
     bool exit;                 // if the program should be exited after the tests are ran/whatever
     bool duration;             // print the time duration of each test case
+    bool minimal;              // minimal console output (only test failures)
     bool quiet;                // no console output
     bool no_throw;             // to skip exceptions-related assertion macros
     bool no_exitcode;          // if the framework should return 0 as the exitcode
@@ -5820,9 +5821,15 @@ namespace {
             }
         }
 
-        void test_run_start() override { printIntro(); }
+        void test_run_start() override {
+            if(!opt.minimal)
+                printIntro();
+        }
 
         void test_run_end(const TestRunStats& p) override {
+            if(opt.minimal)
+                return;
+
             separator_to_stream();
             s << std::dec;
 
@@ -6238,6 +6245,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5829,8 +5829,7 @@ namespace {
         }
 
         void test_run_end(const TestRunStats& p) override {
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            if(opt.minimal && !anythingFailed)
+            if(opt.minimal && p.numTestCasesFailed == 0)
                 return;
 
             separator_to_stream();
@@ -5839,6 +5838,7 @@ namespace {
             auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
             auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
             auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1718,6 +1718,7 @@ public:
 
     void addFilter(const char* filter, const char* value);
     void clearFilters();
+    void setOption(const char* option, bool value);
     void setOption(const char* option, int value);
     void setOption(const char* option, const char* value);
 
@@ -3634,6 +3635,7 @@ Context::~Context() = default;
 void Context::applyCommandLine(int, const char* const*) {}
 void Context::addFilter(const char*, const char*) {}
 void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
 void Context::setOption(const char*, int) {}
 void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
@@ -6313,7 +6315,12 @@ void Context::clearFilters() {
         curr.clear();
 }
 
-// allows the user to override procedurally the int/bool options from the command line
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
+
+// allows the user to override procedurally the int options from the command line
 void Context::setOption(const char* option, int value) {
     setOption(option, toString(value).c_str());
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5829,7 +5829,8 @@ namespace {
         }
 
         void test_run_end(const TestRunStats& p) override {
-            if(opt.minimal)
+            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+            if(opt.minimal && !anythingFailed)
                 return;
 
             separator_to_stream();
@@ -5838,7 +5839,6 @@ namespace {
             auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
             auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
             auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -729,9 +729,8 @@ namespace detail {
 
 struct ContextOptions //!OCLINT too many fields
 {
-    std::ostream* cout;        // stdout stream - std::cout by default
-    std::ostream* cerr;        // stderr stream - std::cerr by default
-    String        binary_name; // the test binary name
+    std::ostream* cout = nullptr; // stdout stream
+    String        binary_name;    // the test binary name
 
     const detail::TestCase* currentTest = nullptr;
 
@@ -750,6 +749,7 @@ struct ContextOptions //!OCLINT too many fields
     bool case_sensitive;       // if filtering should be case sensitive
     bool exit;                 // if the program should be exited after the tests are ran/whatever
     bool duration;             // print the time duration of each test case
+    bool quiet;                // no console output
     bool no_throw;             // to skip exceptions-related assertion macros
     bool no_exitcode;          // if the framework should return 0 as the exitcode
     bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
@@ -1713,6 +1713,8 @@ public:
     void setAsDefaultForAssertsOutOfTestCases();
 
     void setAssertHandler(detail::assert_handler ah);
+
+    void setCout(std::ostream* out);
 
     int run();
 };
@@ -3613,6 +3615,7 @@ void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
 void Context::setAsDefaultForAssertsOutOfTestCases() {}
 void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream* out) {}
 int  Context::run() { return 0; }
 
 IReporter::~IReporter() = default;
@@ -6221,6 +6224,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
@@ -6307,6 +6311,31 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+    class : public std::streambuf
+    {
+    private:
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
+
+    protected:
+        std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
+
+public:
+    DiscardOStream()
+            : std::ostream(&discardBuf) {}
+} discardOut;
+
 // the main function that does all the filtering and test running
 int Context::run() {
     using namespace detail;
@@ -6320,15 +6349,18 @@ int Context::run() {
     g_no_colors = p->no_colors;
     p->resetRunData();
 
-    // stdout by default
-    p->cout = &std::cout;
-    p->cerr = &std::cerr;
-
-    // or to a file if specified
     std::fstream fstr;
-    if(p->out.size()) {
-        fstr.open(p->out.c_str(), std::fstream::out);
-        p->cout = &fstr;
+    if(p->cout == nullptr) {
+        if(p->quiet) {
+            p->cout = &discardOut;
+        } else if (p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+        } else {
+            // stdout by default
+            p->cout = &std::cout;
+        }
     }
 
     FatalConditionHandler::allocateAltStackMem();

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6382,7 +6382,7 @@ int Context::run() {
     if(p->cout == nullptr) {
         if(p->quiet) {
             p->cout = &discardOut;
-        } else if (p->out.size()) {
+        } else if(p->out.size()) {
             // to a file if specified
             fstr.open(p->out.c_str(), std::fstream::out);
             p->cout = &fstr;

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -886,6 +886,7 @@ void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
 void Context::setAsDefaultForAssertsOutOfTestCases() {}
 void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream* out) {}
 int  Context::run() { return 0; }
 
 IReporter::~IReporter() = default;
@@ -3494,6 +3495,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
@@ -3580,6 +3582,31 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+    class : public std::streambuf
+    {
+    private:
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
+
+    protected:
+        std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
+
+public:
+    DiscardOStream()
+            : std::ostream(&discardBuf) {}
+} discardOut;
+
 // the main function that does all the filtering and test running
 int Context::run() {
     using namespace detail;
@@ -3593,15 +3620,18 @@ int Context::run() {
     g_no_colors = p->no_colors;
     p->resetRunData();
 
-    // stdout by default
-    p->cout = &std::cout;
-    p->cerr = &std::cerr;
-
-    // or to a file if specified
     std::fstream fstr;
-    if(p->out.size()) {
-        fstr.open(p->out.c_str(), std::fstream::out);
-        p->cout = &fstr;
+    if(p->cout == nullptr) {
+        if(p->quiet) {
+            p->cout = &discardOut;
+        } else if (p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+        } else {
+            // stdout by default
+            p->cout = &std::cout;
+        }
     }
 
     FatalConditionHandler::allocateAltStackMem();

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -889,6 +889,7 @@ Context::~Context() = default;
 void Context::applyCommandLine(int, const char* const*) {}
 void Context::addFilter(const char*, const char*) {}
 void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
 void Context::setOption(const char*, int) {}
 void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
@@ -3568,7 +3569,12 @@ void Context::clearFilters() {
         curr.clear();
 }
 
-// allows the user to override procedurally the int/bool options from the command line
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
+
+// allows the user to override procedurally the int options from the command line
 void Context::setOption(const char* option, int value) {
     setOption(option, toString(value).c_str());
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3083,7 +3083,8 @@ namespace {
         }
 
         void test_run_end(const TestRunStats& p) override {
-            if(opt.minimal)
+            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+            if(opt.minimal && !anythingFailed)
                 return;
 
             separator_to_stream();
@@ -3092,7 +3093,6 @@ namespace {
             auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
             auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
             auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3076,9 +3076,15 @@ namespace {
             }
         }
 
-        void test_run_start() override { printIntro(); }
+        void test_run_start() override {
+            if(!opt.minimal)
+                printIntro();
+        }
 
         void test_run_end(const TestRunStats& p) override {
+            if(opt.minimal)
+                return;
+
             separator_to_stream();
             s << std::dec;
 
@@ -3494,6 +3500,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3636,7 +3636,7 @@ int Context::run() {
     if(p->cout == nullptr) {
         if(p->quiet) {
             p->cout = &discardOut;
-        } else if (p->out.size()) {
+        } else if(p->out.size()) {
             // to a file if specified
             fstr.open(p->out.c_str(), std::fstream::out);
             p->cout = &fstr;

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3083,8 +3083,7 @@ namespace {
         }
 
         void test_run_end(const TestRunStats& p) override {
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            if(opt.minimal && !anythingFailed)
+            if(opt.minimal && p.numTestCasesFailed == 0)
                 return;
 
             separator_to_stream();
@@ -3093,6 +3092,7 @@ namespace {
             auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
             auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
             auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -726,9 +726,8 @@ namespace detail {
 
 struct ContextOptions //!OCLINT too many fields
 {
-    std::ostream* cout;        // stdout stream - std::cout by default
-    std::ostream* cerr;        // stderr stream - std::cerr by default
-    String        binary_name; // the test binary name
+    std::ostream* cout = nullptr; // stdout stream
+    String        binary_name;    // the test binary name
 
     const detail::TestCase* currentTest = nullptr;
 
@@ -747,6 +746,7 @@ struct ContextOptions //!OCLINT too many fields
     bool case_sensitive;       // if filtering should be case sensitive
     bool exit;                 // if the program should be exited after the tests are ran/whatever
     bool duration;             // print the time duration of each test case
+    bool quiet;                // no console output
     bool no_throw;             // to skip exceptions-related assertion macros
     bool no_exitcode;          // if the framework should return 0 as the exitcode
     bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
@@ -1710,6 +1710,8 @@ public:
     void setAsDefaultForAssertsOutOfTestCases();
 
     void setAssertHandler(detail::assert_handler ah);
+
+    void setCout(std::ostream* out);
 
     int run();
 };

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -758,6 +758,7 @@ struct ContextOptions //!OCLINT too many fields
     bool case_sensitive;       // if filtering should be case sensitive
     bool exit;                 // if the program should be exited after the tests are ran/whatever
     bool duration;             // print the time duration of each test case
+    bool minimal;              // minimal console output (only test failures)
     bool quiet;                // no console output
     bool no_throw;             // to skip exceptions-related assertion macros
     bool no_exitcode;          // if the framework should return 0 as the exitcode

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1715,6 +1715,7 @@ public:
 
     void addFilter(const char* filter, const char* value);
     void clearFilters();
+    void setOption(const char* option, bool value);
     void setOption(const char* option, int value);
     void setOption(const char* option, const char* value);
 

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -92,6 +92,7 @@ doctest_add_test(NAME order_1     ${common_args} -ob=suite -ns          -sf=*tes
 doctest_add_test(NAME order_2     ${common_args} -ob=name               -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_3     ${common_args} -ob=rand               -sfe=*) # exclude everything for no output
 doctest_add_test(NAME quiet       ${common_args} -q -sf=*test_cases_and_suites*) # quiet
+doctest_add_test(NAME minimal     ${common_args} -m -sf=*test_cases_and_suites*) # minimal
 
 ################################################################################
 ## VARIATION OF THE BUILD WITH DOCTEST DISABLED - SHOULD STILL COMPILE

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -31,6 +31,7 @@ set(files_all
     namespace7.cpp
     namespace8.cpp
     namespace9.cpp
+    no_failures.cpp
 )
 
 # add the executable
@@ -86,13 +87,14 @@ doctest_add_test(NAME abort_after ${common_args} -aa=2 -e=off   -sf=*coverage*) 
 doctest_add_test(NAME first_last  ${common_args} -f=2 -l=4      -sf=*coverage*) # run a range
 doctest_add_test(NAME filter_1    ${common_args} -ts=none) # should filter out all
 # -order-by=name to avoid different output depending on the compiler used. See https://github.com/onqtam/doctest/issues/287
-doctest_add_test(NAME filter_2    COMMAND $<TARGET_FILE:all_features>   -tse=* -nv -order-by=name) # should filter out all + print skipped
-doctest_add_test(NAME filter_3    ${common_args} -sc=from*,sc* -sce=sc2 -sf=*subcases*) # enter a specific subcase - sc1
-doctest_add_test(NAME order_1     ${common_args} -ob=suite -ns          -sf=*test_cases_and_suites*)
-doctest_add_test(NAME order_2     ${common_args} -ob=name               -sf=*test_cases_and_suites*)
-doctest_add_test(NAME order_3     ${common_args} -ob=rand               -sfe=*) # exclude everything for no output
-doctest_add_test(NAME quiet       ${common_args} -q -sf=*test_cases_and_suites*) # quiet
-doctest_add_test(NAME minimal     ${common_args} -m -sf=*test_cases_and_suites*) # minimal
+doctest_add_test(NAME filter_2        COMMAND $<TARGET_FILE:all_features>   -tse=* -nv -order-by=name) # should filter out all + print skipped
+doctest_add_test(NAME filter_3        ${common_args} -sc=from*,sc* -sce=sc2 -sf=*subcases*) # enter a specific subcase - sc1
+doctest_add_test(NAME order_1         ${common_args} -ob=suite -ns          -sf=*test_cases_and_suites*)
+doctest_add_test(NAME order_2         ${common_args} -ob=name               -sf=*test_cases_and_suites*)
+doctest_add_test(NAME order_3         ${common_args} -ob=rand               -sfe=*) # exclude everything for no output
+doctest_add_test(NAME quiet           ${common_args} -q -sf=*test_cases_and_suites*) # quiet
+doctest_add_test(NAME minimal         ${common_args} -m -sf=*test_cases_and_suites*) # minimal with summary
+doctest_add_test(NAME minimal_no_fail ${common_args} -m -sf=*no_failures.cpp) # minimal
 
 ################################################################################
 ## VARIATION OF THE BUILD WITH DOCTEST DISABLED - SHOULD STILL COMPILE

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -92,7 +92,7 @@ doctest_add_test(NAME filter_3        ${common_args} -sc=from*,sc* -sce=sc2 -sf=
 doctest_add_test(NAME order_1         ${common_args} -ob=suite -ns          -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_2         ${common_args} -ob=name               -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_3         ${common_args} -ob=rand               -sfe=*) # exclude everything for no output
-doctest_add_test(NAME quiet           ${common_args} -q -sf=*test_cases_and_suites*) # quiet
+doctest_add_test(NO_OUTPUT NAME quiet ${common_args} -q -sf=*test_cases_and_suites*) # quiet
 doctest_add_test(NAME minimal         ${common_args} -m -sf=*test_cases_and_suites*) # minimal with summary
 doctest_add_test(NAME minimal_no_fail ${common_args} -m -sf=*no_failures.cpp) # minimal
 

--- a/examples/all_features/no_failures.cpp
+++ b/examples/all_features/no_failures.cpp
@@ -1,0 +1,13 @@
+#include <doctest/doctest.h>
+
+TEST_CASE("no checks") {}
+
+TEST_CASE("simple check") {
+    CHECK(1 == 1);
+}
+
+TEST_SUITE("some suite") {
+    TEST_CASE("fails - and its allowed" * doctest::may_fail()) { FAIL(""); }
+}
+
+TEST_CASE("should fail and no output" * doctest::should_fail() * doctest::no_breaks() * doctest::no_output()) { FAIL(""); }

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 90 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 94 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -51,6 +51,9 @@
     <TestCase name="explicit failures 2" filename="logging.cpp" line="0" skipped="true"/>
     <TestCase name="expressions should be evaluated only once" filename="assertion_macros.cpp" line="0" skipped="true"/>
   </TestSuite>
+  <TestSuite name="some suite">
+    <TestCase name="fails - and its allowed" filename="no_failures.cpp" line="0" may_fail="true" skipped="true"/>
+  </TestSuite>
   <TestSuite name="test suite with a description">
     <TestCase name="fails - and its allowed" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" may_fail="true" skipped="true"/>
     <TestCase name="fails 1 time as it should" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" skipped="true"/>
@@ -84,6 +87,7 @@
     <TestCase name="namespace 7 member vs global" filename="namespace7.cpp" line="0" skipped="true"/>
     <TestCase name="namespace 8 friend vs global" filename="namespace8.cpp" line="0" skipped="true"/>
     <TestCase name="namespace 9 both global" filename="namespace9.cpp" line="0" skipped="true"/>
+    <TestCase name="no checks" filename="no_failures.cpp" line="0" skipped="true"/>
     <TestCase name="normal macros" filename="assertion_macros.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite name="ts1">
@@ -97,11 +101,13 @@
     <TestCase name="part of some TS" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite>
+    <TestCase name="should fail and no output" filename="no_failures.cpp" line="0" should_fail="true" skipped="true"/>
     <TestCase name="should fail and no output" filename="test_cases_and_suites.cpp" line="0" should_fail="true" skipped="true"/>
     <TestCase name="should fail because of an exception" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
     <TestCase name="signed integers stuff&lt;int>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
     <TestCase name="signed integers stuff&lt;short int>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
     <TestCase name="signed integers stuff&lt;signed char>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
+    <TestCase name="simple check" filename="no_failures.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite name="skipped test cases">
     <TestCase name="skipped - inherited from the test suite" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
@@ -128,6 +134,6 @@
     <TestCase name="will end from an unknown exception" filename="coverage_maxout.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="90"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="94"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/minimal.txt
+++ b/examples/all_features/test_output/minimal.txt
@@ -93,4 +93,8 @@ test_cases_and_suites.cpp(0): ERROR:
 test_cases_and_suites.cpp(0): ERROR: 
 
 Didn't fail exactly 1 times so marking it as failed!
+===============================================================================
+[doctest] test cases: 15 | 6 passed |  9 failed |
+[doctest] assertions: 12 | 1 passed | 11 failed |
+[doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/minimal.txt
+++ b/examples/all_features/test_output/minimal.txt
@@ -1,0 +1,96 @@
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST CASE:  should fail because of an exception
+
+test_cases_and_suites.cpp(0): ERROR: test case THREW exception: 0
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST SUITE: scoped test suite
+TEST CASE:  part of scoped
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST SUITE: scoped test suite
+TEST CASE:  part of scoped 2
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST SUITE: some TS
+TEST CASE:  part of some TS
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST CASE:  fixtured test - not part of a test suite
+
+test_cases_and_suites.cpp(0): ERROR: CHECK( data == 85 ) is NOT correct!
+  values: CHECK( 21 == 85 )
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+TEST SUITE: ts1
+TEST CASE:  normal test in a test suite from a decorator
+
+test_cases_and_suites.cpp(0): MESSAGE: failing because of the timeout decorator!
+
+Test case exceeded time limit of 0.000001!
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: this test has overridden its skip decorator
+TEST SUITE: skipped test cases
+TEST CASE:  unskipped
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: regarding failures
+TEST SUITE: test suite with a description
+TEST CASE:  fails - and its allowed
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+Allowed to fail so marking it as not failed
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: regarding failures
+TEST SUITE: test suite with a description
+TEST CASE:  fails as it should
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+Failed as expected so marking it as not failed
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: regarding failures
+TEST SUITE: test suite with a description
+TEST CASE:  doesn't fail but it should have
+
+Should have failed but didn't! Marking it as failed!
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: regarding failures
+TEST SUITE: test suite with a description
+TEST CASE:  fails 1 time as it should
+
+test_cases_and_suites.cpp(0): FATAL ERROR: 
+
+Failed exactly 1 times as expected so marking it as not failed!
+===============================================================================
+test_cases_and_suites.cpp(0):
+DESCRIPTION: regarding failures
+TEST SUITE: test suite with a description
+TEST CASE:  fails more times as it should
+
+test_cases_and_suites.cpp(0): ERROR: 
+
+test_cases_and_suites.cpp(0): ERROR: 
+
+Didn't fail exactly 1 times so marking it as failed!
+Program code.

--- a/examples/all_features/test_output/minimal_junit.txt
+++ b/examples/all_features/test_output/minimal_junit.txt
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="all_features" errors="1" failures="1" tests="12">
+    <testcase classname="test_cases_and_suites.cpp" name="an empty test that will succeed - not part of a test suite" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="should fail because of an exception" status="run">
+      <error message="exception">
+        0
+      </error>
+    </testcase>
+    <testcase classname="test_cases_and_suites.cpp" name="part of scoped" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="part of scoped 2" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="part of some TS" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="fixtured test - not part of a test suite" status="run">
+      <failure message="21 == 85" type="CHECK">
+test_cases_and_suites.cpp(0):
+CHECK( data == 85 ) is NOT correct!
+  values: CHECK( 21 == 85 )
+
+      </failure>
+    </testcase>
+    <testcase classname="test_cases_and_suites.cpp" name="normal test in a test suite from a decorator" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="unskipped" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="fails - and its allowed" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="doesn't fail which is fine" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="fails as it should" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="doesn't fail but it should have" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="fails 1 time as it should" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="fails more times as it should" status="run"/>
+    <testcase classname="test_cases_and_suites.cpp" name="should fail and no output" status="run"/>
+  </testsuite>
+</testsuites>
+Program code.

--- a/examples/all_features/test_output/minimal_no_fail.txt
+++ b/examples/all_features/test_output/minimal_no_fail.txt
@@ -1,0 +1,9 @@
+===============================================================================
+no_failures.cpp(0):
+TEST SUITE: some suite
+TEST CASE:  fails - and its allowed
+
+no_failures.cpp(0): FATAL ERROR: 
+
+Allowed to fail so marking it as not failed
+Program code.

--- a/examples/all_features/test_output/minimal_no_fail_junit.txt
+++ b/examples/all_features/test_output/minimal_no_fail_junit.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="all_features" errors="0" failures="0" tests="3">
+    <testcase classname="no_failures.cpp" name="no checks" status="run"/>
+    <testcase classname="no_failures.cpp" name="simple check" status="run"/>
+    <testcase classname="no_failures.cpp" name="fails - and its allowed" status="run"/>
+    <testcase classname="no_failures.cpp" name="should fail and no output" status="run"/>
+  </testsuite>
+</testsuites>
+Program code.

--- a/examples/all_features/test_output/minimal_no_fail_xml.txt
+++ b/examples/all_features/test_output/minimal_no_fail_xml.txt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="all_features">
+  <Options order_by="file" rand_seed="324" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="no checks" filename="no_failures.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0"/>
+    </TestCase>
+    <TestCase name="simple check" filename="no_failures.cpp" line="0">
+      <OverallResultsAsserts successes="1" failures="0"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="some suite">
+    <TestCase name="fails - and its allowed" filename="no_failures.cpp" line="0" may_fail="true">
+      <Message type="FATAL ERROR" filename="no_failures.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite>
+    <TestCase name="should fail and no output" filename="no_failures.cpp" line="0" should_fail="true">
+      <Message type="FATAL ERROR" filename="no_failures.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="1" failures="2"/>
+  <OverallResultsTestCases successes="4" failures="0"/>
+</doctest>
+Program code.

--- a/examples/all_features/test_output/minimal_xml.txt
+++ b/examples/all_features/test_output/minimal_xml.txt
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="all_features">
+  <Options order_by="file" rand_seed="324" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="an empty test that will succeed - not part of a test suite" filename="test_cases_and_suites.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0"/>
+    </TestCase>
+    <TestCase name="should fail because of an exception" filename="test_cases_and_suites.cpp" line="0">
+      <Exception crash="false">
+        0
+      </Exception>
+      <OverallResultsAsserts successes="1" failures="0"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="scoped test suite">
+    <TestCase name="part of scoped" filename="test_cases_and_suites.cpp" line="0">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+    <TestCase name="part of scoped 2" filename="test_cases_and_suites.cpp" line="0">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="some TS">
+    <TestCase name="part of some TS" filename="test_cases_and_suites.cpp" line="0">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite>
+    <TestCase name="fixtured test - not part of a test suite" filename="test_cases_and_suites.cpp" line="0">
+      <Expression success="false" type="CHECK" filename="test_cases_and_suites.cpp" line="0">
+        <Original>
+          data == 85
+        </Original>
+        <Expanded>
+          21 == 85
+        </Expanded>
+      </Expression>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="ts1">
+    <TestCase name="normal test in a test suite from a decorator" filename="test_cases_and_suites.cpp" line="0">
+      <Message type="WARNING" filename="test_cases_and_suites.cpp" line="0">
+        <Text>
+          failing because of the timeout decorator!
+        </Text>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="0"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="skipped test cases">
+    <TestCase name="unskipped" filename="test_cases_and_suites.cpp" line="0" description="this test has overridden its skip decorator">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite name="test suite with a description">
+    <TestCase name="fails - and its allowed" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" may_fail="true">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+    <TestCase name="doesn't fail which is fine" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" may_fail="true">
+      <OverallResultsAsserts successes="0" failures="0"/>
+    </TestCase>
+    <TestCase name="fails as it should" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" should_fail="true">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+    <TestCase name="doesn't fail but it should have" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" should_fail="true">
+      <OverallResultsAsserts successes="0" failures="0"/>
+    </TestCase>
+    <TestCase name="fails 1 time as it should" filename="test_cases_and_suites.cpp" line="0" description="regarding failures">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1" expected_failures="1"/>
+    </TestCase>
+    <TestCase name="fails more times as it should" filename="test_cases_and_suites.cpp" line="0" description="regarding failures">
+      <Message type="ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <Message type="ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="2" expected_failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <TestSuite>
+    <TestCase name="should fail and no output" filename="test_cases_and_suites.cpp" line="0" should_fail="true">
+      <Message type="FATAL ERROR" filename="test_cases_and_suites.cpp" line="0">
+        <Text/>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="1"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="1" failures="11"/>
+  <OverallResultsTestCases successes="6" failures="9"/>
+</doctest>
+Program code.

--- a/examples/all_features/test_output/quiet.txt
+++ b/examples/all_features/test_output/quiet.txt
@@ -1,1 +1,0 @@
-Program code.

--- a/examples/all_features/test_output/quiet_junit.txt
+++ b/examples/all_features/test_output/quiet_junit.txt
@@ -1,1 +1,0 @@
-Program code.

--- a/examples/all_features/test_output/quiet_xml.txt
+++ b/examples/all_features/test_output/quiet_xml.txt
@@ -1,1 +1,0 @@
-Program code.


### PR DESCRIPTION
## Description
As discussed in #561 a less extreme form of -quiet is probably pretty useful as well, excludes the header and summary, leaving only all failing tests.

P.S.: Sorry for not including a test with my previous PR!