### PR TITLE
Support pretty printing of container based on heuristics

### DIFF
--- a/scripts/playground/CMakeLists.txt
+++ b/scripts/playground/CMakeLists.txt
@@ -5,3 +5,4 @@ doctest_add_test(NAME playground NO_OUTPUT COMMAND $<TARGET_FILE:playground> -nv
 
 #add_custom_command(TARGET playground POST_BUILD COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
 #add_custom_command(TARGET playground POST_BUILD COMMAND ctest -C $<CONFIGURATION> --output-on-failure)
+


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
There are a lot of complaints about the fact, that vector values and other containers output as "{?}" because their stringification is not supported.

I think that it should not be much hard to support standard containers (or at least most of them) without including nothing but type_traits.

```c++
template<typename T, typename = void> struct has_begin_end_overloads : std::false_type {};
template<typename T>                  struct has_begin_end_overloads<T, std::void_t<
    decltype( std::begin( std::declval<T>() ) != std::end( std::declval<T>() ) )
    >> : std::true_type {};
template<typename T> constexpr bool has_begin_end_overloads_v = has_begin_end_overloads<T>::value;

template<typename T, typename = void> struct has_mapped_type : std::false_type {};
template<typename T>                  struct has_mapped_type<T, std::void_t<
    typename T::mapped_type
    >> : std::true_type {};
template<typename T> constexpr bool has_mapped_type_v = has_mapped_type<T>::value;

template<typename T> constexpr bool is_element_container_v = has_begin_end_overloads_v<remove_all_t<T>> && !has_mapped_type_v<remove_all_t<T>>;
// output as [X, Y, Z]
// detects vector, list, deque, set etc. works even with old good C arrays

template<typename T> constexpr bool is_key_value_container_v = has_begin_end_overloads_v<remove_all_t<T>> && has_mapped_type_v<remove_all_t<T>>;
// output as {X: XX, Y: YY, Z: ZZ}
// works with map and unordered_map
```

I have written such code for my closed sourced project and it took less than 300 LOC to support stringification of pairs, tuples, pointers, etc. Unfortunately, it is ported to C++17 but with some effort, code can be adapted to C++11.

I'm sure that this stringification would be a great optional feature (enabled by default or not) and doesn't bloat the code at all. But benchmarks should measure it better as soon there is something to measure.

I often use doctest here and there and I'm bored to copy-paste vertor stringification again and again and again. I prefer it to be in the doctest, even in a disabled state by default.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
#121, #170, #192, #248