### PR TITLE
Add tests for default stringification result of doctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ if(MAIN_PROJECT AND DOCTEST_WITH_TESTS)
     include(scripts/cmake/common.cmake)
 
     add_subdirectory(examples/all_features)
+    add_subdirectory(examples/stringification)
 
     # for code coverage we want exactly one binary to be produced and exercised
     if(NOT DEFINED ENV{CODE_COVERAGE})

--- a/examples/stringification/CMakeLists.txt
+++ b/examples/stringification/CMakeLists.txt
@@ -1,0 +1,44 @@
+# separated executable to ensure there is no specializations of StringMaker leaked
+# In opposite to all_features/stringification.cpp this test intended to check all the bundled
+# output rules for all the fundamental types, std containers etc
+# it might overlap with other tests, but better to test twice, than miss some cases
+add_executable(stringification main.cpp)
+target_link_libraries(stringification doctest)
+target_compile_definitions(stringification PRIVATE SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P})
+if(MSVC)
+    # See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+    target_compile_options(stringification PUBLIC "/Zc:__cplusplus")
+endif()
+
+doctest_add_test_2(NAME stringification_all COMMAND $<TARGET_FILE:stringification>)
+
+# Unfortunately tests could and actually do affect each other, so rerun each test case separately
+doctest_detect_test_cases(main.cpp stringification_test_cases)
+foreach(test_case IN LISTS stringification_test_cases)
+    string(MAKE_C_IDENTIFIER "${test_case}" test_case_identifier)
+    string(TOLOWER "${test_case_identifier}" test_case_identifier)
+    doctest_add_test_2(NAME "stringification_${test_case_identifier}" COMMAND $<TARGET_FILE:stringification> --test-case=${test_case})
+endforeach()
+
+if(MSVC)
+    target_compile_options(stringification PRIVATE /wd4505) # unreferenced local function has been removed
+    target_compile_options(stringification PRIVATE /wd4100) # unreferenced formal parameter
+    target_compile_options(stringification PRIVATE /wd4189) # local variable is initialized but not referenced
+    target_compile_options(stringification PRIVATE /wd4312) # 'reinterpret_cast': conversion from 'unsigned int' to 'int *' of greater size
+    target_compile_options(stringification PRIVATE /wd5245) # '`anonymous-namespace'::operator <<': unreferenced function with internal linkage has been removed
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(stringification PRIVATE -Wno-unknown-warning-option)
+    target_compile_options(stringification PRIVATE -Wno-unneeded-internal-declaration)
+    target_compile_options(stringification PRIVATE -Wno-unused-function)
+    target_compile_options(stringification PRIVATE -Wno-unused-parameter)
+    target_compile_options(stringification PRIVATE -Wno-unused-variable)
+    target_compile_options(stringification PRIVATE -Wno-unused-template)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_compile_options(stringification PRIVATE -Wno-unused-function)
+    target_compile_options(stringification PRIVATE -Wno-unused-parameter)
+    target_compile_options(stringification PRIVATE -Wno-unused-variable)
+    target_compile_options(stringification PRIVATE -Wno-switch-default)
+    target_compile_options(stringification PRIVATE -Wno-useless-cast) # static_casts used to explicitly set used type
+endif()

--- a/examples/stringification/CMakeLists.txt
+++ b/examples/stringification/CMakeLists.txt
@@ -10,14 +10,17 @@ if(MSVC)
     target_compile_options(stringification PUBLIC "/Zc:__cplusplus")
 endif()
 
-doctest_add_test_2(NAME stringification_all COMMAND $<TARGET_FILE:stringification>)
+# omit the version and the num test cases skipped from the summary - this way the output will change less often
+set(common_args COMMAND $<TARGET_FILE:stringification> --no-skipped-summary --no-version)
+
+doctest_add_test(NAME stringification_all COMMAND ${common_args})
 
 # Unfortunately tests could and actually do affect each other, so rerun each test case separately
 doctest_detect_test_cases(main.cpp stringification_test_cases)
 foreach(test_case IN LISTS stringification_test_cases)
     string(MAKE_C_IDENTIFIER "${test_case}" test_case_identifier)
     string(TOLOWER "${test_case_identifier}" test_case_identifier)
-    doctest_add_test_2(NAME "stringification_${test_case_identifier}" COMMAND $<TARGET_FILE:stringification> --test-case=${test_case})
+    doctest_add_test(NAME "stringification_${test_case_identifier}" COMMAND ${common_args} --test-case=${test_case})
 endforeach()
 
 if(MSVC)

--- a/examples/stringification/main.cpp
+++ b/examples/stringification/main.cpp
@@ -1,0 +1,437 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+// Pass
+#if __cplusplus >= 202002L
+#   define CXX_STANDARD 20
+#elif __cplusplus >= 201703L
+#   define CXX_STANDARD 17
+#elif __cplusplus >= 201402L
+#   define CXX_STANDARD 14
+#elif __cplusplus >= 201103L
+#   define CXX_STANDARD 11
+#else
+#   define CXX_STANDARD 3
+#endif
+
+#include <ostream>
+
+#include <string>
+#include <utility>
+#include <tuple>
+#include <array>
+#include <valarray>
+#include <initializer_list>
+#include <vector>
+#include <deque>
+#include <list>
+#include <forward_list>
+#include <stack>
+#include <queue>
+#include <set>
+#include <map>
+
+#if CXX_STANDARD >= 14
+#   include <string_view>
+#endif
+
+#if CXX_STANDARD >= 17
+#   include <optional>
+#   include <variant>
+#endif
+
+#if CXX_STANDARD >= 20
+#   include <span>
+#endif
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace
+{
+
+enum Enum
+{
+    E_VALUE = 1
+};
+
+enum EnumWithOss
+{
+    E_VALUE_WITH_OSS = 2
+};
+
+std::ostream& operator<<( std::ostream& os, EnumWithOss value )
+{
+    switch (value) {
+    case EnumWithOss::E_VALUE_WITH_OSS:
+        os << "E_VALUE_WITH_OSS";
+        break;
+    }
+    return os;
+}
+
+enum class EnumClass : int
+{
+    VALUE = 3
+};
+
+enum class EnumClassWithOss : int
+{
+    A = 4
+};
+
+std::ostream& operator<<( std::ostream& os, EnumClassWithOss value )
+{
+    switch (value) {
+    case EnumClassWithOss::A:
+        os << "A";
+        break;
+    }
+    return os;
+}
+
+struct Struct
+{
+};
+
+struct StructOss
+{
+    int value;
+};
+
+inline std::ostream& operator<<(std::ostream& os, StructOss s)
+{
+    return os << s.value;
+}
+
+}
+
+//#define ENABLE_BROKEN_TESTS
+
+using namespace doctest;
+
+TEST_CASE("nullptr_t")
+{
+    CHECK_EQ(toString(nullptr), "NULL");
+}
+
+TEST_CASE("Integer_types")
+{
+    CHECK_EQ(toString(static_cast<short int>(-15679)), "-15679");
+    CHECK_EQ(toString(static_cast<short int>(0)), "0");
+    CHECK_EQ(toString(static_cast<short int>(28154)), "28154");
+    
+    CHECK_EQ(toString(static_cast<unsigned short int>(0u)), "0");
+    CHECK_EQ(toString(static_cast<unsigned short int>(42407u)), "42407");
+    
+    CHECK_EQ(toString(static_cast<int>(-26985)), "-26985");
+    CHECK_EQ(toString(static_cast<int>(0)), "0");
+    CHECK_EQ(toString(static_cast<int>(51425)), "51425");
+    
+    CHECK_EQ(toString(static_cast<unsigned int>(0u)), "0");
+    CHECK_EQ(toString(static_cast<unsigned int>(57974u)), "57974");
+    
+    CHECK_EQ(toString(static_cast<long int>(-8088342l)), "-8088342");
+    CHECK_EQ(toString(static_cast<long int>(0l)), "0");
+    CHECK_EQ(toString(static_cast<long int>(7784301l)), "7784301");
+    
+    CHECK_EQ(toString(static_cast<unsigned long int>(0ul)), "0");
+    CHECK_EQ(toString(static_cast<unsigned long int>(396060450ul)), "396060450");
+    
+    CHECK_EQ(toString(static_cast<long long int>(-38997570817ll)), "-38997570817");
+    CHECK_EQ(toString(static_cast<long long int>(0ll)), "0");
+    CHECK_EQ(toString(static_cast<long long int>(21204560479ll)), "21204560479");
+    
+    CHECK_EQ(toString(static_cast<unsigned long long int>(0ull)), "0");
+    CHECK_EQ(toString(static_cast<unsigned long long int>(13324909658562760708ull)), "13324909658562760708");
+}
+
+TEST_CASE("Boolean_type")
+{
+    CHECK_EQ(toString(true), "true");
+    CHECK_EQ(toString(false), "false");
+}
+
+TEST_CASE("Standard_character_types")
+{
+    CHECK_EQ(toString(static_cast<signed char>('A')), "65");
+    CHECK_EQ(toString(static_cast<unsigned char>('B')), "66");
+    CHECK_EQ(toString(static_cast<char>('C')), "67");
+}
+
+// String representation is lost in c++20 for whatever reason
+TEST_CASE("Wide_character_types")
+{
+#ifdef ENABLE_BROKEN_TESTS
+#if CXX_STANDARD >= 20
+    CHECK_EQ(toString(static_cast<wchar_t>(L'A')), "{?}");
+    CHECK_EQ(toString(static_cast<char16_t>(L'B')), "{?}");
+    CHECK_EQ(toString(static_cast<char32_t>(L'C')), "{?}");
+#else
+    CHECK_EQ(toString(static_cast<wchar_t>(L'A')), "65");
+    CHECK_EQ(toString(static_cast<char16_t>(L'B')), "66");
+    CHECK_EQ(toString(static_cast<char32_t>(L'C')), "67");
+#endif
+#endif
+}
+
+TEST_CASE("Floating_point_types_zero")
+{
+    CHECK_EQ(toString(static_cast<float>(0.0f)), "0.0f");
+    CHECK_EQ(toString(static_cast<double>(0.0)), "0.0");
+    CHECK_EQ(toString(static_cast<long double>(0.0L)), "0.0");
+}
+
+// Output format is quite fragile due to absence of output precision
+// For example 904.1f may be printed as 904.09998f
+// I have no idea how to test it reliably due to this fact
+TEST_CASE("Floating_point_types__non_zero" * may_fail())
+{
+    CHECK_EQ(toString(static_cast<float>(-10.0f)), "-10.0f");
+    CHECK_EQ(toString(static_cast<float>(-1.1f)), "-1.1f");
+    CHECK_EQ(toString(static_cast<float>(105.1f)), "105.1f");
+    CHECK_EQ(toString(static_cast<float>(51425.0f)), "51425.0f");
+    
+    CHECK_EQ(toString(static_cast<double>(-10.0)), "-10.0");
+    CHECK_EQ(toString(static_cast<double>(-1.1)), "-1.1");
+    CHECK_EQ(toString(static_cast<double>(105.1)), "105.1");
+    CHECK_EQ(toString(static_cast<double>(51425.0)), "51425.0");
+    
+    CHECK_EQ(toString(static_cast<long double>(-10.0L)), "-10.0");
+    CHECK_EQ(toString(static_cast<long double>(-1.1L)), "-1.1");
+    CHECK_EQ(toString(static_cast<long double>(15.1L)), "15.1");
+    CHECK_EQ(toString(static_cast<long double>(51425.0L)), "51425.0");
+}
+
+TEST_CASE("Pointer_types")
+{
+#if SIZEOF_VOID_P == 4
+#   define POINTER_PREFIX "0x"
+#elif SIZEOF_VOID_P == 8
+#   define POINTER_PREFIX "0x00000000"
+#endif
+    
+    // doctest overloads toString() for pointer types. So string doesn't match ostreamed result
+    // NULL is handled separatly somewhat
+    // other value representation has fixed size string representation depending on sizeof(void*)
+    CHECK_EQ(toString(static_cast<int*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<int*>(0xABADF00D)), POINTER_PREFIX "abadf00d");
+    
+    CHECK_EQ(toString(static_cast<signed char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<signed char*>(0xDEADBABE)), POINTER_PREFIX "deadbabe");
+    
+    CHECK_EQ(toString(static_cast<unsigned char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<unsigned char*>(0xB16B00B5)), POINTER_PREFIX "b16b00b5");
+    
+    CHECK_EQ(toString(static_cast<char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<char*>(0xFEEDFACE)), POINTER_PREFIX "feedface");
+    
+    CHECK_EQ(toString(static_cast<wchar_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<wchar_t*>(0xDEFEC8ED)), POINTER_PREFIX "defec8ed");
+    
+    CHECK_EQ(toString(static_cast<char16_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<char16_t*>(0xBEEFCACE)), POINTER_PREFIX "beefcace");
+    
+    CHECK_EQ(toString(static_cast<char32_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<char32_t*>(0xCAFEBABE)), POINTER_PREFIX "cafebabe");
+
+    // constant versions
+    CHECK_EQ(toString(static_cast<const int*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const int*>(0xABADF00D)), POINTER_PREFIX "abadf00d");
+    
+    CHECK_EQ(toString(static_cast<const signed char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const signed char*>(0xDEADBABE)), POINTER_PREFIX "deadbabe");
+    
+    CHECK_EQ(toString(static_cast<const unsigned char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const unsigned char*>(0xB16B00B5)), POINTER_PREFIX "b16b00b5");
+    
+    CHECK_EQ(toString(static_cast<const char*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const char*>(0xFEEDFACE)), POINTER_PREFIX "feedface");
+    
+    CHECK_EQ(toString(static_cast<const wchar_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const wchar_t*>(0xDEFEC8ED)), POINTER_PREFIX "defec8ed");
+    
+    CHECK_EQ(toString(static_cast<const char16_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const char16_t*>(0xBEEFCACE)), POINTER_PREFIX "beefcace");
+    
+    CHECK_EQ(toString(static_cast<const char32_t*>(nullptr)), "NULL");
+    CHECK_EQ(toString(reinterpret_cast<const char32_t*>(0xCAFEBABE)), POINTER_PREFIX "cafebabe");
+}
+
+TEST_CASE("C_arrays")
+{
+#ifdef ENABLE_BROKEN_TESTS
+    // TODO: cover more types. Especially character types
+    {
+        const char ztConstCharArray[] = {'f', 'o', 'o', '\0'};  CHECK_EQ(toString(ztConstCharArray), "foo");
+        char ztCharArray[] = {'b', 'a', 'r', '\0'};             CHECK_EQ(toString(ztCharArray), "bar");
+    }
+
+    const char constCharArray[] = {'f', 'o', 'o'};          CHECK_EQ(toString(constCharArray), "foo");
+    char charArray[] = {'b', 'a', 'r'};                     CHECK_EQ(toString(charArray), "bar");
+    const int constIntArray[] = {1, 2, 3};                  CHECK_EQ(toString(constIntArray), "[1, 2, 3]");
+    const int intArray[] = {4, 5, 6};                       CHECK_EQ(toString(intArray), "[4, 5, 6]");
+#endif
+}
+
+TEST_CASE("Enumerations")
+{
+    CHECK_EQ(toString(Enum::E_VALUE), "1");
+    CHECK_EQ(toString(EnumClass::VALUE), "3");
+#ifdef ENABLE_BROKEN_TESTS
+    CHECK_EQ(toString(EnumWithOss::E_VALUE_WITH_OSS), "E_VALUE_WITH_OSS");
+    CHECK_EQ(toString(EnumClassWithOss::A), "A");
+#endif
+}
+
+TEST_CASE("Structs")
+{
+    CHECK_EQ(toString(Struct{}), "{?}"); // No overloaded operator, no text representation
+    CHECK_EQ(toString(StructOss{7}), "7"); // Use overloaded ostream operator
+}
+
+TEST_CASE("std_classes")
+{
+#if CXX_STANDARD >= 11
+    
+    {
+        const std::string value = "Hello world!";
+        CHECK_EQ(toString(value), "Hello world!");
+    }
+
+    {
+        std::pair<int, float> value { 1, 2.3f };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::tuple<bool, int, double> value { false, 7, 6.6 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+    {
+        std::array<int, 3> value {{ 1, 5, 8 }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::valarray<int> value { 7, 3, 2 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::initializer_list<int> value { 1, 7, 0 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::vector<int> value { 4, 2, 7 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::deque<int> value { 1, 1, 6, 2 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::list<int> value { 7, 5, 2, 1 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::forward_list<int> value { 7, 0, 3, 7, 4 };
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::stack<int> value {{ 1, 2, 3, 4, 5 }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        std::queue<int> value {{ 1, 2, 3, 4, 5 }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+
+    {
+        const auto data = { 1, 8, 5, 6, 3 };
+
+        std::priority_queue<int> value { data.begin(), data.end() };
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+    {
+        std::set<int> value {{ 1, 2, 2, 6, 1, 4 }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+    {
+        std::multiset<int> value {{ 1, 2, 2, 6, 1, 4 }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+    {
+        std::map<int, std::string> value {{ { 1, "foo" }, { 2, "bar" }, { 1, "baz" } }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+    {
+        std::multimap<int, std::string> value {{ { 1, "foo" }, { 2, "bar" }, { 1, "baz" } }};
+        CHECK_EQ(toString(value), "{?}");
+    }
+#endif  // CXX_STANDARD >= 11
+
+#if CXX_STANDARD >= 14
+    {
+        std::integer_sequence<int, 9, 2, 5, 1, 9, 1, 6> value {};
+        CHECK_EQ(toString(value), "{?}");
+    }
+#endif  // CXX_STANDARD >= 14
+
+#if CXX_STANDARD >= 17
+    {
+        const std::string s = "Hello world!";
+        std::string_view value{ s };
+        value = value.substr(0, 5);
+        CHECK_EQ(toString(value), "Hello"); // standard ostream operator is used
+    }
+    
+    {
+        CHECK_EQ(toString(std::nullopt), "{?}");
+        std::optional<int> value {};
+        CHECK_EQ(toString(value), "{?}");
+        value = 9;
+        CHECK_EQ(toString(value), "{?}");
+    }
+    
+#if !DOCTEST_MSVC || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 29, 0)) // MSVC v141 has defect is default constructable std::variant
+    {
+        std::variant<std::monostate, int, bool> value {};
+        CHECK_EQ(toString(value), "{?}"); // std::monostate
+        value = 5;
+        CHECK_EQ(toString(value), "{?}");
+        value = true;
+        CHECK_EQ(toString(value), "{?}");
+    }
+#endif
+    
+#endif  // CXX_STANDARD >= 17
+
+#if CXX_STANDARD >= 20
+    {
+        std::array<int, 3> ar {{ 9, 1, 5 }};
+        std::span<int> value { ar };
+        CHECK_EQ(toString(value), "{?}");
+    }
+#endif  // CXX_STANDARD >= 20
+}
+
+#ifdef ENABLE_BROKEN_TESTS
+TEST_CASE("Ostream_poisoning_regression")
+{
+    // Hex result of toString shouldn't leave internal stream mode into hex mode
+    CHECK_EQ(toString(StructOss{16}), "16");
+    toString(reinterpret_cast<int*>(0xBEEFCACE));
+    CHECK_EQ(toString(StructOss{16}), "16");
+}
+#endif

--- a/examples/stringification/main.cpp
+++ b/examples/stringification/main.cpp
@@ -116,7 +116,7 @@ inline std::ostream& operator<<(std::ostream& os, StructSpoiledHexOss s)
 
 }
 
-#define ENABLE_BROKEN_TESTS
+//#define ENABLE_BROKEN_TESTS
 
 using namespace doctest;
 

--- a/examples/stringification/main.cpp
+++ b/examples/stringification/main.cpp
@@ -105,7 +105,7 @@ inline std::ostream& operator<<(std::ostream& os, StructOss s)
 
 }
 
-//#define ENABLE_BROKEN_TESTS
+#define ENABLE_BROKEN_TESTS
 
 using namespace doctest;
 

--- a/examples/stringification/main.cpp
+++ b/examples/stringification/main.cpp
@@ -103,6 +103,17 @@ inline std::ostream& operator<<(std::ostream& os, StructOss s)
     return os << s.value;
 }
 
+struct StructSpoiledHexOss
+{
+    int value;
+};
+
+inline std::ostream& operator<<(std::ostream& os, StructSpoiledHexOss s)
+{
+    // set ostream mode to hex and not return it back
+    return os << std::hex << s.value;
+}
+
 }
 
 #define ENABLE_BROKEN_TESTS
@@ -432,6 +443,16 @@ TEST_CASE("Ostream_poisoning_regression")
     // Hex result of toString shouldn't leave internal stream mode into hex mode
     CHECK_EQ(toString(StructOss{16}), "16");
     toString(reinterpret_cast<int*>(0xBEEFCACE));
+    CHECK_EQ(toString(StructOss{16}), "16");
+}
+
+TEST_CASE("Ostream_poisoning_regression_2")
+{
+    // Hex result of toString shouldn't leave internal stream mode into hex mode
+    // ideally even if source of the spoiling is in the user code
+    // because such spoiling is not detectable immideatly, but breaks random asserts that are called after
+    CHECK_EQ(toString(StructOss{16}), "16");
+    toString(StructSpoiledHexOss{12345});
     CHECK_EQ(toString(StructOss{16}), "16");
 }
 #endif

--- a/examples/stringification/test_output/stringification_all.txt
+++ b/examples/stringification/test_output/stringification_all.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 12 | 12 passed | 0 failed |
-[doctest] assertions: 99 | 99 passed | 0 failed |
+[doctest] test cases:  14 |  14 passed | 0 failed |
+[doctest] assertions: 114 | 114 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_all.txt
+++ b/examples/stringification/test_output/stringification_all.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 12 | 12 passed | 0 failed |
+[doctest] assertions: 99 | 99 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_all_junit.txt
+++ b/examples/stringification/test_output/stringification_all_junit.txt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="99">
+    <testcase classname="main.cpp" name="nullptr_t" status="run"/>
+    <testcase classname="main.cpp" name="Integer_types" status="run"/>
+    <testcase classname="main.cpp" name="Boolean_type" status="run"/>
+    <testcase classname="main.cpp" name="Standard_character_types" status="run"/>
+    <testcase classname="main.cpp" name="Wide_character_types" status="run"/>
+    <testcase classname="main.cpp" name="Floating_point_types_zero" status="run"/>
+    <testcase classname="main.cpp" name="Floating_point_types__non_zero" status="run"/>
+    <testcase classname="main.cpp" name="Pointer_types" status="run"/>
+    <testcase classname="main.cpp" name="C_arrays" status="run"/>
+    <testcase classname="main.cpp" name="Enumerations" status="run"/>
+    <testcase classname="main.cpp" name="Structs" status="run"/>
+    <testcase classname="main.cpp" name="std_classes" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_all_junit.txt
+++ b/examples/stringification/test_output/stringification_all_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="99">
+  <testsuite name="stringification" errors="0" failures="0" tests="114">
     <testcase classname="main.cpp" name="nullptr_t" status="run"/>
     <testcase classname="main.cpp" name="Integer_types" status="run"/>
     <testcase classname="main.cpp" name="Boolean_type" status="run"/>
@@ -13,5 +13,7 @@
     <testcase classname="main.cpp" name="Enumerations" status="run"/>
     <testcase classname="main.cpp" name="Structs" status="run"/>
     <testcase classname="main.cpp" name="std_classes" status="run"/>
+    <testcase classname="main.cpp" name="Ostream_poisoning_regression" status="run"/>
+    <testcase classname="main.cpp" name="Ostream_poisoning_regression_2" status="run"/>
   </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_all_xml.txt
+++ b/examples/stringification/test_output/stringification_all_xml.txt
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="nullptr_t" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="1" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Integer_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="20" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Boolean_type" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Standard_character_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Wide_character_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Floating_point_types_zero" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Floating_point_types__non_zero" filename="main.cpp" line="0" may_fail="true">
+      <OverallResultsAsserts successes="12" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Pointer_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="28" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="C_arrays" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Enumerations" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Structs" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="std_classes" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="26" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="99" failures="0"/>
+  <OverallResultsTestCases successes="12" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_all_xml.txt
+++ b/examples/stringification/test_output/stringification_all_xml.txt
@@ -15,7 +15,7 @@
       <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
     </TestCase>
     <TestCase name="Wide_character_types" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
     </TestCase>
     <TestCase name="Floating_point_types_zero" filename="main.cpp" line="0">
       <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
@@ -27,10 +27,10 @@
       <OverallResultsAsserts successes="28" failures="0" test_case_success="true"/>
     </TestCase>
     <TestCase name="C_arrays" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="6" failures="0" test_case_success="true"/>
     </TestCase>
     <TestCase name="Enumerations" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="4" failures="0" test_case_success="true"/>
     </TestCase>
     <TestCase name="Structs" filename="main.cpp" line="0">
       <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
@@ -38,7 +38,13 @@
     <TestCase name="std_classes" filename="main.cpp" line="0">
       <OverallResultsAsserts successes="26" failures="0" test_case_success="true"/>
     </TestCase>
+    <TestCase name="Ostream_poisoning_regression" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="Ostream_poisoning_regression_2" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="99" failures="0"/>
-  <OverallResultsTestCases successes="12" failures="0"/>
+  <OverallResultsAsserts successes="114" failures="0"/>
+  <OverallResultsTestCases successes="14" failures="0"/>
 </doctest>

--- a/examples/stringification/test_output/stringification_boolean_type.txt
+++ b/examples/stringification/test_output/stringification_boolean_type.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 2 | 2 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_boolean_type_junit.txt
+++ b/examples/stringification/test_output/stringification_boolean_type_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="2">
+    <testcase classname="main.cpp" name="Boolean_type" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_boolean_type_xml.txt
+++ b/examples/stringification/test_output/stringification_boolean_type_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Boolean_type" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_c_arrays.txt
+++ b/examples/stringification/test_output/stringification_c_arrays.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
 [doctest] test cases: 1 | 1 passed | 0 failed |
-[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] assertions: 6 | 6 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_c_arrays.txt
+++ b/examples/stringification/test_output/stringification_c_arrays.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_c_arrays_junit.txt
+++ b/examples/stringification/test_output/stringification_c_arrays_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="0">
+    <testcase classname="main.cpp" name="C_arrays" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_c_arrays_junit.txt
+++ b/examples/stringification/test_output/stringification_c_arrays_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="0">
+  <testsuite name="stringification" errors="0" failures="0" tests="6">
     <testcase classname="main.cpp" name="C_arrays" status="run"/>
   </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_c_arrays_xml.txt
+++ b/examples/stringification/test_output/stringification_c_arrays_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="C_arrays" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_c_arrays_xml.txt
+++ b/examples/stringification/test_output/stringification_c_arrays_xml.txt
@@ -3,9 +3,9 @@
   <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
   <TestSuite>
     <TestCase name="C_arrays" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="6" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsAsserts successes="6" failures="0"/>
   <OverallResultsTestCases successes="1" failures="0"/>
 </doctest>

--- a/examples/stringification/test_output/stringification_enumerations.txt
+++ b/examples/stringification/test_output/stringification_enumerations.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 2 | 2 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_enumerations.txt
+++ b/examples/stringification/test_output/stringification_enumerations.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
 [doctest] test cases: 1 | 1 passed | 0 failed |
-[doctest] assertions: 2 | 2 passed | 0 failed |
+[doctest] assertions: 4 | 4 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_enumerations_junit.txt
+++ b/examples/stringification/test_output/stringification_enumerations_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="2">
+  <testsuite name="stringification" errors="0" failures="0" tests="4">
     <testcase classname="main.cpp" name="Enumerations" status="run"/>
   </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_enumerations_junit.txt
+++ b/examples/stringification/test_output/stringification_enumerations_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="2">
+    <testcase classname="main.cpp" name="Enumerations" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_enumerations_xml.txt
+++ b/examples/stringification/test_output/stringification_enumerations_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Enumerations" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_enumerations_xml.txt
+++ b/examples/stringification/test_output/stringification_enumerations_xml.txt
@@ -3,9 +3,9 @@
   <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
   <TestSuite>
     <TestCase name="Enumerations" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="4" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsAsserts successes="4" failures="0"/>
   <OverallResultsTestCases successes="1" failures="0"/>
 </doctest>

--- a/examples/stringification/test_output/stringification_floating_point_types__non_zero.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types__non_zero.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases:  1 |  1 passed | 0 failed |
+[doctest] assertions: 12 | 12 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_floating_point_types__non_zero_junit.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types__non_zero_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="12">
+    <testcase classname="main.cpp" name="Floating_point_types__non_zero" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_floating_point_types__non_zero_xml.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types__non_zero_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Floating_point_types__non_zero" filename="main.cpp" line="0" may_fail="true">
+      <OverallResultsAsserts successes="12" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="12" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_floating_point_types_zero.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types_zero.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 3 | 3 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_floating_point_types_zero_junit.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types_zero_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="3">
+    <testcase classname="main.cpp" name="Floating_point_types_zero" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_floating_point_types_zero_xml.txt
+++ b/examples/stringification/test_output/stringification_floating_point_types_zero_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Floating_point_types_zero" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="3" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_integer_types.txt
+++ b/examples/stringification/test_output/stringification_integer_types.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases:  1 |  1 passed | 0 failed |
+[doctest] assertions: 20 | 20 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_integer_types_junit.txt
+++ b/examples/stringification/test_output/stringification_integer_types_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="20">
+    <testcase classname="main.cpp" name="Integer_types" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_integer_types_xml.txt
+++ b/examples/stringification/test_output/stringification_integer_types_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Integer_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="20" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="20" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_nullptr_t.txt
+++ b/examples/stringification/test_output/stringification_nullptr_t.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 1 | 1 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_nullptr_t_junit.txt
+++ b/examples/stringification/test_output/stringification_nullptr_t_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="1">
+    <testcase classname="main.cpp" name="nullptr_t" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_nullptr_t_xml.txt
+++ b/examples/stringification/test_output/stringification_nullptr_t_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="nullptr_t" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="1" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="1" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed |
-[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 2 | 2 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed |
-[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 2 | 2 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_junit.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_junit.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="0"/>
+</testsuites>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_junit.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_junit.txt
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="0"/>
+  <testsuite name="stringification" errors="0" failures="0" tests="2">
+    <testcase classname="main.cpp" name="Ostream_poisoning_regression_2" status="run"/>
+  </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_xml.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsTestCases successes="0" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_xml.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_2_xml.txt
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctest binary="stringification">
   <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
-  <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0"/>
+  <TestSuite>
+    <TestCase name="Ostream_poisoning_regression_2" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
 </doctest>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_junit.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_junit.txt
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="0"/>
+  <testsuite name="stringification" errors="0" failures="0" tests="2">
+    <testcase classname="main.cpp" name="Ostream_poisoning_regression" status="run"/>
+  </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_junit.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_junit.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="0"/>
+</testsuites>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_xml.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_xml.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsTestCases successes="0" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_ostream_poisoning_regression_xml.txt
+++ b/examples/stringification/test_output/stringification_ostream_poisoning_regression_xml.txt
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctest binary="stringification">
   <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
-  <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0"/>
+  <TestSuite>
+    <TestCase name="Ostream_poisoning_regression" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
 </doctest>

--- a/examples/stringification/test_output/stringification_pointer_types.txt
+++ b/examples/stringification/test_output/stringification_pointer_types.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases:  1 |  1 passed | 0 failed |
+[doctest] assertions: 28 | 28 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_pointer_types_junit.txt
+++ b/examples/stringification/test_output/stringification_pointer_types_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="28">
+    <testcase classname="main.cpp" name="Pointer_types" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_pointer_types_xml.txt
+++ b/examples/stringification/test_output/stringification_pointer_types_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Pointer_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="28" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="28" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_standard_character_types.txt
+++ b/examples/stringification/test_output/stringification_standard_character_types.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 3 | 3 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_standard_character_types_junit.txt
+++ b/examples/stringification/test_output/stringification_standard_character_types_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="3">
+    <testcase classname="main.cpp" name="Standard_character_types" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_standard_character_types_xml.txt
+++ b/examples/stringification/test_output/stringification_standard_character_types_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Standard_character_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="3" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_std_classes.txt
+++ b/examples/stringification/test_output/stringification_std_classes.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases:  1 |  1 passed | 0 failed |
+[doctest] assertions: 26 | 26 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_std_classes_junit.txt
+++ b/examples/stringification/test_output/stringification_std_classes_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="26">
+    <testcase classname="main.cpp" name="std_classes" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_std_classes_xml.txt
+++ b/examples/stringification/test_output/stringification_std_classes_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="std_classes" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="26" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="26" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_structs.txt
+++ b/examples/stringification/test_output/stringification_structs.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 2 | 2 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_structs_junit.txt
+++ b/examples/stringification/test_output/stringification_structs_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="2">
+    <testcase classname="main.cpp" name="Structs" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_structs_xml.txt
+++ b/examples/stringification/test_output/stringification_structs_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Structs" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="2" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="2" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_wide_character_types.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types.txt
@@ -1,5 +1,5 @@
 [doctest] run with "--help" for options
 ===============================================================================
 [doctest] test cases: 1 | 1 passed | 0 failed |
-[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] assertions: 3 | 3 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_wide_character_types.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types.txt
@@ -1,0 +1,5 @@
+[doctest] run with "--help" for options
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] Status: SUCCESS!

--- a/examples/stringification/test_output/stringification_wide_character_types_junit.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types_junit.txt
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="stringification" errors="0" failures="0" tests="0">
+    <testcase classname="main.cpp" name="Wide_character_types" status="run"/>
+  </testsuite>
+</testsuites>

--- a/examples/stringification/test_output/stringification_wide_character_types_junit.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="stringification" errors="0" failures="0" tests="0">
+  <testsuite name="stringification" errors="0" failures="0" tests="3">
     <testcase classname="main.cpp" name="Wide_character_types" status="run"/>
   </testsuite>
 </testsuites>

--- a/examples/stringification/test_output/stringification_wide_character_types_xml.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types_xml.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="stringification">
+  <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="Wide_character_types" filename="main.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>

--- a/examples/stringification/test_output/stringification_wide_character_types_xml.txt
+++ b/examples/stringification/test_output/stringification_wide_character_types_xml.txt
@@ -3,9 +3,9 @@
   <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
   <TestSuite>
     <TestCase name="Wide_character_types" filename="main.cpp" line="0">
-      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsAsserts successes="3" failures="0"/>
   <OverallResultsTestCases successes="1" failures="0"/>
 </doctest>

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -72,31 +72,6 @@ function(doctest_add_test)
     doctest_add_test_impl(${ARGN} JUNIT_OUTPUT)
 endfunction()
 
-# Unlike doctest_add_test we need to add doctest as a regular test
-# I mean test which output is not checked, but instead we check retcode
-# TODO: think of a better name
-function(doctest_add_test_2)
-    cmake_parse_arguments(ARG "" "NAME" "COMMAND" ${ARGN})
-    if(NOT "${ARG_UNPARSED_ARGUMENTS}" STREQUAL "" OR "${ARG_NAME}" STREQUAL "" OR "${ARG_COMMAND}" STREQUAL "")
-        message(FATAL_ERROR "doctest_add_stringification_test() called with wrong options!")
-    endif()
-    
-    # construct the command
-    set(the_command "")
-    if(${DOCTEST_TEST_MODE} STREQUAL "VALGRIND")
-        set(the_command "valgrind -v --leak-check=full --track-origins=yes --error-exitcode=1")
-    endif()
-    foreach(cur ${ARG_COMMAND})
-        set(the_command "${the_command} ${cur}")
-    endforeach()
-    
-    string(STRIP ${the_command} the_command)
-    
-    list(APPEND ADDITIONAL_FLAGS -DTEST_MODE=${the_test_mode})
-    
-    add_test(NAME ${ARG_NAME} COMMAND ${CMAKE_COMMAND} -DCOMMAND=${the_command} ${ADDITIONAL_FLAGS} -P ${CURRENT_LIST_DIR_CACHED}/exec_test.cmake)
-endfunction()
-
 # In order not to miss subcases, parse a file with regex to find them
 function(doctest_detect_test_cases FILE_NAME OUTPUT_NAME)
     file(READ "${FILE_NAME}" file_content)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Use doctest to self-test itself. Stringification tests cannot be added in the "all_features" trash can, because code from it poisons new tests (namely StringMaker<std::list<T>>).

Also, the approach of other tests is not quite applicable here, because they are actually approval tests that work on program output level. I was really surprised when I added my test that should fall, with NO_OUTPUT
```cmake
doctest_add_test(NO_OUTPUT NAME stringification_all COMMAND $<TARGET_FILE:stringification>)
```
but it wasn't and I saw such output in the console:
```
133: [doctest] doctest version is "2.4.8"
133: [doctest] run with "--help" for options
133: ===============================================================================
133: main.cpp(0):
133: TEST CASE:  C_arrays
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(constCharArray), "foo" ) is NOT correct!
133:   values: CHECK_EQ( foo╞ , foo )
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(constIntArray), "[1, 2, 3]" ) is NOT correct!
133:   values: CHECK_EQ( 123, [1, 2, 3] )
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(intArray), "[4, 5, 6]" ) is NOT correct!
133:   values: CHECK_EQ( 456, [4, 5, 6] )
133: 
133: ===============================================================================
133: main.cpp(0):
133: TEST CASE:  Enumerations
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(EnumWithOss::E_VALUE_WITH_OSS), "E_VALUE_WITH_OSS" ) is NOT correct!
133:   values: CHECK_EQ( 2, E_VALUE_WITH_OSS )
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(EnumClassWithOss::A), "A" ) is NOT correct!
133:   values: CHECK_EQ( 4, A )
133: 
133: ===============================================================================
133: main.cpp(0):
133: TEST CASE:  Structs
133: 
133: main.cpp(0): ERROR: CHECK_EQ( toString(StructOss{777}), "777" ) is NOT correct!
133:   values: CHECK_EQ( 309, 777 )
133: 
133: ===============================================================================
133: [doctest] test cases:  12 |   9 passed | 3 failed | 0 skipped
133: [doctest] assertions: 110 | 104 passed | 6 failed |
133: [doctest] Status: FAILURE!
```

Some tests falls now, but it is ok because currently doctest itself is a little broken and tests just point at this fact.

Based on work commented here https://github.com/doctest/doctest/pull/585.

And on a separate project https://github.com/YarikTH/doctest_stringify_test.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
