### PR TITLE
Ignore CMake and MacOS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,32 @@ bazel-*
 *.xcodeproj/
 XCBuildData/
 
+# Visual Studio
+*.vcxproj
+*.vcxproj.filters
+*.sln
+*.lastbuildstate
+*.recipe
+*.tlog
+*.exp
+*.ilk
+*.pdb
+
+# Ninja
+build.ninja
+.ninja_log
+.ninja_deps
+
 # CMake generated
 CMakeFiles/
 CMakeScripts/
 generated/
 cmake_install.cmake
+CTestTestFile.cmake
 CMakeCache.txt
+*.FileListAbsolute.txt
+CTestCostData.txt
+*.Build.CppClean.log
+LastTest.log
+LastTestsFailed.log
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,15 @@ build-mingw/
 .idea/
 cmake-build-*/
 bazel-*
+
+# MacOS/Xcode
+*.DS_Store
+*.xcodeproj/
+XCBuildData/
+
+# CMake generated
+CMakeFiles/
+CMakeScripts/
+generated/
+cmake_install.cmake
+CMakeCache.txt


### PR DESCRIPTION
Ignores macOS .DS_Store files, Xcode project files, and CMake generated files. These files keep showing up as "changes" when doctest is added in as a git submodule and included in a CMake project.