### PR TITLE
Fix MPI extension to work if launched without mpirun/mpiexec

### DIFF
--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -21,7 +21,7 @@ int nb_test_cases_skipped_insufficient_procs = 0;
 // Record size of MPI_COMM_WORLD with mpi_comm_world_size()
 // so that it can be compared to the MPI_Comm_size value
 // once MPI_Init_thread has been called
-int world_size_before_init = -1;
+int world_size_before_init = 1;
 
 
 std::string thread_level_to_string(int thread_lvl);


### PR DESCRIPTION
## Description
A bug was introduced by PR #611: now if the doctest mpi extension is lauched without mpirun/mpiexec, it triggers an internal error, whereas it really should execute sequential tests and report parallel tests as skipped.

Turns out this is a one character change... Sorry for not noticing it

