### PR TITLE
Allow escaping backslash with backslash in filters (#614)

### DIFF
--- a/doc/markdown/commandline.md
+++ b/doc/markdown/commandline.md
@@ -9,7 +9,9 @@
 **Bool options** - they expect ```1```/```yes```/```on```/```true``` or ```0```/```no```/```off```/```false``` after the ```=``` sign - but they can also be used like flags and the ```=value``` part can be skipped - then ```true``` is assumed.  
 
 **Filters** - a comma-separated list of wildcards for matching values - where ```*``` means "match any sequence" and ```?``` means "match any one character".
-To pass patterns with intervals use ```""``` like this:  ```--test-case="*no sound*,vaguely named test number ?"```. Patterns that contain a comma can be escaped with ```\``` (example: ```--test-case=this\,test\,has\,commas```).
+To pass patterns with intervals use ```""``` like this:  ```--test-case="*no sound*,vaguely named test number ?"```. Patterns that contain a comma or a backslash can be escaped with ```\``` (example: ```--test-case=this\,test\,has\,commas\,and\,a\\\,backslash\,followed\,by\,a\,comma```).
+If a backslash is followed by neither ```\``` nor ```,``` it's left as is, e.g. ```--test-case="Test that \ works correctly"```.
+Be careful: your shell may use ```\``` for escaping as well, so `\` may actually get consumed by the shell instead of doctest.
 
 All the options can also be set with code (defaults/overrides) if the user [**supplies the ```main()``` function**](main.md).
 

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6302,8 +6302,8 @@ namespace {
                 char character = *current++;
                 if(seenBackslash) {
                     seenBackslash = false;
-                    if(character == ',') {
-                        s.put(',');
+                    if(character == ',' || character == '\\') {
+                        s.put(character);
                         continue;
                     }
                     s.put('\\');

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3332,8 +3332,8 @@ namespace {
                 char character = *current++;
                 if(seenBackslash) {
                     seenBackslash = false;
-                    if(character == ',') {
-                        s.put(',');
+                    if(character == ',' || character == '\\') {
+                        s.put(character);
                         continue;
                     }
                     s.put('\\');

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -89,7 +89,7 @@ doctest_add_test(NAME filter_1    ${common_args} -ts=none) # should filter out a
 # -order-by=name to avoid different output depending on the compiler used. See https://github.com/doctest/doctest/issues/287
 doctest_add_test(NAME filter_2        COMMAND $<TARGET_FILE:all_features>   -tse=* -nv -order-by=name) # should filter out all + print skipped
 doctest_add_test(NAME filter_3        ${common_args} -sc=from*,sc* -sce=sc2 -sf=*subcases*) # enter a specific subcase - sc1
-doctest_add_test(NAME filter_4        ${common_args} -ts=*\\, -tc=*\\: -sc=*\\,,*:) # escape stuff
+doctest_add_test(NAME filter_4        ${common_args} -ts=*\\, -tc=*\\: -sc=*\\\\\\,,*:) # escape stuff
 doctest_add_test(NAME order_1         ${common_args} -ob=suite -ns          -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_2         ${common_args} -ob=name               -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_3         ${common_args} -ob=rand               -sfe=*) # exclude everything for no output

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -89,6 +89,7 @@ doctest_add_test(NAME filter_1    ${common_args} -ts=none) # should filter out a
 # -order-by=name to avoid different output depending on the compiler used. See https://github.com/doctest/doctest/issues/287
 doctest_add_test(NAME filter_2        COMMAND $<TARGET_FILE:all_features>   -tse=* -nv -order-by=name) # should filter out all + print skipped
 doctest_add_test(NAME filter_3        ${common_args} -sc=from*,sc* -sce=sc2 -sf=*subcases*) # enter a specific subcase - sc1
+doctest_add_test(NAME filter_4        ${common_args} -ts=*\\, -tc=*\\: -sc=*\\,,*:) # escape stuff
 doctest_add_test(NAME order_1         ${common_args} -ob=suite -ns          -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_2         ${common_args} -ob=name               -sf=*test_cases_and_suites*)
 doctest_add_test(NAME order_3         ${common_args} -ob=rand               -sfe=*) # exclude everything for no output

--- a/examples/all_features/subcases.cpp
+++ b/examples/all_features/subcases.cpp
@@ -158,3 +158,21 @@ TEST_CASE("subcases with changing names") {
         MESSAGE("separate msg!");
     }
 }
+
+TEST_SUITE("with a funny name,") {
+    TEST_CASE("with a funnier name\\:") {
+        SUBCASE("with the funniest name\\,") {
+            MESSAGE("Yes!");
+        }
+        SUBCASE("with a slightly funny name :") {
+            MESSAGE("Yep!");
+        }
+        SUBCASE("without a funny name") {
+            MESSAGE("NO!");
+        }
+    }
+
+    TEST_CASE("without a funny name:") {
+        MESSAGE("Nooo");
+    }
+}

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 96 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 98 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -135,7 +135,11 @@
     <TestCase name="will end from a std::string exception" filename="coverage_maxout.cpp" line="0" skipped="true"/>
     <TestCase name="will end from an unknown exception" filename="coverage_maxout.cpp" line="0" skipped="true"/>
   </TestSuite>
+  <TestSuite name="with a funny name,">
+    <TestCase name="with a funnier name\:" filename="subcases.cpp" line="0" skipped="true"/>
+    <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
+  </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="96"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="98"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/filter_3.txt
+++ b/examples/all_features/test_output/filter_3.txt
@@ -27,7 +27,14 @@ DEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):
 subcases.cpp(0): MESSAGE: lala
 
 ===============================================================================
-[doctest] test cases: 7 | 7 passed | 0 failed |
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  without a funny name:
+
+subcases.cpp(0): MESSAGE: Nooo
+
+===============================================================================
+[doctest] test cases: 9 | 9 passed | 0 failed |
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_3_junit.txt
+++ b/examples/all_features/test_output/filter_3_junit.txt
@@ -10,6 +10,8 @@ root
     <testcase classname="subcases.cpp" name="fails from an exception but gets re-entered to traverse all subcases" status="run"/>
     <testcase classname="subcases.cpp" name="Nested - related to https://github.com/doctest/doctest/issues/282" status="run"/>
     <testcase classname="subcases.cpp" name="subcases with changing names" status="run"/>
+    <testcase classname="subcases.cpp" name="with a funnier name\:" status="run"/>
+    <testcase classname="subcases.cpp" name="without a funny name:" status="run"/>
   </testsuite>
 </testsuites>
 Program code.

--- a/examples/all_features/test_output/filter_3_xml.txt
+++ b/examples/all_features/test_output/filter_3_xml.txt
@@ -45,7 +45,20 @@ root
       <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
+  <TestSuite name="with a funny name,">
+    <TestCase name="with a funnier name\:" filename="subcases.cpp" line="0">
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="without a funny name:" filename="subcases.cpp" line="0">
+      <Message type="WARNING" filename="subcases.cpp" line="0">
+        <Text>
+          Nooo
+        </Text>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="7" failures="0"/>
+  <OverallResultsTestCases successes="9" failures="0"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/filter_4.txt
+++ b/examples/all_features/test_output/filter_4.txt
@@ -1,0 +1,22 @@
+[doctest] run with "--help" for options
+===============================================================================
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  with a funnier name\:
+  with the funniest name\,
+
+subcases.cpp(0): MESSAGE: Yes!
+
+===============================================================================
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  with a funnier name\:
+  with a slightly funny name :
+
+subcases.cpp(0): MESSAGE: Yep!
+
+===============================================================================
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
+[doctest] Status: SUCCESS!
+Program code.

--- a/examples/all_features/test_output/filter_4_junit.txt
+++ b/examples/all_features/test_output/filter_4_junit.txt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="all_features" errors="0" failures="0" tests="0">
+    <testcase classname="subcases.cpp" name="with a funnier name\:/with the funniest name\," status="run"/>
+    <testcase classname="subcases.cpp" name="with a funnier name\:/with a slightly funny name :" status="run"/>
+  </testsuite>
+</testsuites>
+Program code.

--- a/examples/all_features/test_output/filter_4_xml.txt
+++ b/examples/all_features/test_output/filter_4_xml.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="all_features">
+  <Options order_by="file" rand_seed="324" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite name="with a funny name,">
+    <TestCase name="with a funnier name\:" filename="subcases.cpp" line="0">
+      <SubCase name="with the funniest name\," filename="subcases.cpp" line="0">
+        <Message type="WARNING" filename="subcases.cpp" line="0">
+          <Text>
+            Yes!
+          </Text>
+        </Message>
+      </SubCase>
+      <SubCase name="with a slightly funny name :" filename="subcases.cpp" line="0">
+        <Message type="WARNING" filename="subcases.cpp" line="0">
+          <Text>
+            Yep!
+          </Text>
+        </Message>
+      </SubCase>
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="0" failures="0"/>
+  <OverallResultsTestCases successes="1" failures="0"/>
+</doctest>
+Program code.

--- a/examples/all_features/test_output/subcases.cpp.txt
+++ b/examples/all_features/test_output/subcases.cpp.txt
@@ -194,7 +194,38 @@ TEST CASE:  subcases with changing names
 subcases.cpp(0): MESSAGE: separate msg!
 
 ===============================================================================
-[doctest] test cases:  7 |  3 passed | 4 failed |
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  with a funnier name\:
+  with the funniest name\,
+
+subcases.cpp(0): MESSAGE: Yes!
+
+===============================================================================
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  with a funnier name\:
+  with a slightly funny name :
+
+subcases.cpp(0): MESSAGE: Yep!
+
+===============================================================================
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  with a funnier name\:
+  without a funny name
+
+subcases.cpp(0): MESSAGE: NO!
+
+===============================================================================
+subcases.cpp(0):
+TEST SUITE: with a funny name,
+TEST CASE:  without a funny name:
+
+subcases.cpp(0): MESSAGE: Nooo
+
+===============================================================================
+[doctest] test cases:  9 |  5 passed | 4 failed |
 [doctest] assertions: 25 | 19 passed | 6 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/subcases.cpp_junit.txt
+++ b/examples/all_features/test_output/subcases.cpp_junit.txt
@@ -81,6 +81,10 @@ CHECK( false ) is NOT correct!
     <testcase classname="subcases.cpp" name="subcases with changing names/outer 1/inner 0" status="run"/>
     <testcase classname="subcases.cpp" name="subcases with changing names/outer 1/inner 1" status="run"/>
     <testcase classname="subcases.cpp" name="subcases with changing names/separate" status="run"/>
+    <testcase classname="subcases.cpp" name="with a funnier name\:/with the funniest name\," status="run"/>
+    <testcase classname="subcases.cpp" name="with a funnier name\:/with a slightly funny name :" status="run"/>
+    <testcase classname="subcases.cpp" name="with a funnier name\:/without a funny name" status="run"/>
+    <testcase classname="subcases.cpp" name="without a funny name:" status="run"/>
   </testsuite>
 </testsuites>
 Program code.

--- a/examples/all_features/test_output/subcases.cpp_xml.txt
+++ b/examples/all_features/test_output/subcases.cpp_xml.txt
@@ -235,7 +235,41 @@ root
       <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
+  <TestSuite name="with a funny name,">
+    <TestCase name="with a funnier name\:" filename="subcases.cpp" line="0">
+      <SubCase name="with the funniest name\," filename="subcases.cpp" line="0">
+        <Message type="WARNING" filename="subcases.cpp" line="0">
+          <Text>
+            Yes!
+          </Text>
+        </Message>
+      </SubCase>
+      <SubCase name="with a slightly funny name :" filename="subcases.cpp" line="0">
+        <Message type="WARNING" filename="subcases.cpp" line="0">
+          <Text>
+            Yep!
+          </Text>
+        </Message>
+      </SubCase>
+      <SubCase name="without a funny name" filename="subcases.cpp" line="0">
+        <Message type="WARNING" filename="subcases.cpp" line="0">
+          <Text>
+            NO!
+          </Text>
+        </Message>
+      </SubCase>
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+    <TestCase name="without a funny name:" filename="subcases.cpp" line="0">
+      <Message type="WARNING" filename="subcases.cpp" line="0">
+        <Text>
+          Nooo
+        </Text>
+      </Message>
+      <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+    </TestCase>
+  </TestSuite>
   <OverallResultsAsserts successes="19" failures="6"/>
-  <OverallResultsTestCases successes="3" failures="4"/>
+  <OverallResultsTestCases successes="5" failures="4"/>
 </doctest>
 Program code.


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
All filters now treat double backslash as a single backslash. It allows specifying strings like `\,` in filters and is more consistent with other escaping systems. E.g. it's now possible to run a test called `a\,` with `-tc=a\\\,`.

That way it's possible to pass any test name to the `-tc`, which is important for IDEs like CLion. They had some integration issues previously to this and #493: https://youtrack.jetbrains.com/issue/CPP-25111

## GitHub Issues
Closes #614 