### PR TITLE
Add contains option to checks.

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -133,6 +133,19 @@ Checkout the [**example**](../../examples/all_features/asserts_used_outside_of_t
 
 Currently [**logging macros**](logging.md) cannot be used for extra context for asserts outside of a test run. That means that the ```_MESSAGE``` variants of asserts are also not usable - since they are just a packed ```INFO()``` with an assert right after it.
 
+## String containment
+
+```doctest::Contains``` can be used to check whether the string passed to its constructor is contained within the string it is compared with. Here's a simple example:
+
+```c++
+REQUIRE("foobar" == doctest::Contains("foo"));
+```
+
+It can also be used with the ```THROWS_WITH``` family of assertion macros to check whether the thrown exception [translated to a string](stringification.md#translating-exceptions) contains the provided string. Here's another example:
+```c++
+REQUIRE_THROWS_WITH(func(), doctest::Contains("Oopsie"));
+```
+
 ## Floating point comparisons
 
 When comparing floating point numbers - especially if at least one of them has been computed - great care must be taken to allow for rounding errors and inexact representations.

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -765,6 +765,23 @@ struct DOCTEST_INTERFACE AssertData
         }
     } m_exception_string = { String("") };
     bool           m_contains;
+
+   // AssertData(const AssertData& assert_data) 
+   // : m_contains(assert_data.m_contains) {
+   //     if(assert_data.m_contains) {
+   //         m_exception_string.contains = assert_data.m_exception_string.contains;
+   //     } else {
+   //         m_exception_string.string = assert_data.m_exception_string.string;
+   //     }
+   //}
+
+    ~AssertData() {
+        if (m_contains) {
+            m_exception_string.contains.~Contains();
+        } else {
+            m_exception_string.string.~String();
+        }
+    }
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -739,15 +739,6 @@ struct DOCTEST_INTERFACE TestCaseData
 
 struct DOCTEST_INTERFACE AssertData
 {
-    union StringContains {
-        String string;
-        Contains contains;
-
-        StringContains()
-            : string("") {}
-
-        ~StringContains() {}
-    };
     // common - for all asserts
     const TestCaseData* m_test_case;
     assertType::Enum    m_at;
@@ -766,16 +757,14 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool           m_threw_as;
     const char*    m_exception_type;
-    StringContains m_exception_string;
-    bool           m_contains;
+    union StringContains {
+        String string;
+        Contains contains;
 
-    ~AssertData() {
-        if (m_contains) {
-            m_exception_string.contains.~Contains();
-        } else {
-            m_exception_string.string.~String();
+        ~StringContains() {
         }
-   }
+    } m_exception_string = { String("") };
+    bool           m_contains;
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -583,9 +583,14 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const char* string);\
 
+    Contains();
     ~Contains();
+    
+    explicit Contains(const char* string);
+    
+    explicit Contains(const Contains& other);
+    Contains& operator=(const Contains& other);
 
     bool checkWith(const String& other) const;
 
@@ -3680,12 +3685,25 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-Contains::Contains(const char* in){
-    string = String(in);
+
+Contains::Contains() {
+    string = "";
 }
 
 Contains::~Contains(){
     string.~String();
+}
+
+Contains::Contains(const char* in){
+    string = String(in);
+}
+
+Contains::Contains(const Contains& other)
+: string(other.string) {}
+
+Contains& Contains::operator=(const Contains& other) {
+    string = other.string;
+    return *this;
 }
 
 bool Contains::checkWith(const String& full_string) const {

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -583,7 +583,9 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const char* string);
+    explicit Contains(const char* string);\
+
+    ~Contains();
 
     bool checkWith(const String& other) const;
 
@@ -3680,6 +3682,10 @@ int String::compare(const String& other, bool no_case) const {
 
 Contains::Contains(const char* in){
     string = String(in);
+}
+
+Contains::~Contains(){
+    string.~String();
 }
 
 bool Contains::checkWith(const String& full_string) const {

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -583,14 +583,9 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-
-    Contains();
-    ~Contains();
-    
     explicit Contains(const char* string);
-    
-    explicit Contains(const Contains& other);
-    Contains& operator=(const Contains& other);
+
+    ~Contains();
 
     bool checkWith(const String& other) const;
 
@@ -764,31 +759,16 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool           m_threw_as;
     const char*    m_exception_type;
-    union StringContains {
+    struct StringContains {
         String string;
         Contains contains;
 
-        ~StringContains() {
-        }
-    } m_exception_string = { String("") };
+        StringContains()
+            : string(""), contains("") {}
+
+        //~StringContains() {}
+    } m_exception_string;
     bool           m_contains;
-
-   // AssertData(const AssertData& assert_data) 
-   // : m_contains(assert_data.m_contains) {
-   //     if(assert_data.m_contains) {
-   //         m_exception_string.contains = assert_data.m_exception_string.contains;
-   //     } else {
-   //         m_exception_string.string = assert_data.m_exception_string.string;
-   //     }
-   //}
-
-    ~AssertData() {
-        if (m_contains) {
-            m_exception_string.contains.~Contains();
-        } else {
-            m_exception_string.string.~String();
-        }
-    }
 };
 
 struct DOCTEST_INTERFACE MessageData
@@ -3685,25 +3665,12 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-
-Contains::Contains() {
-    string = "";
-}
-
-Contains::~Contains(){
-    string.~String();
-}
-
 Contains::Contains(const char* in){
     string = String(in);
 }
 
-Contains::Contains(const Contains& other)
-: string(other.string) {}
-
-Contains& Contains::operator=(const Contains& other) {
-    string = other.string;
-    return *this;
+Contains::~Contains(){
+    string.~String();
 }
 
 bool Contains::checkWith(const String& full_string) const {
@@ -4789,7 +4756,7 @@ namespace detail {
         m_failed           = true;
         m_threw            = false;
         m_threw_as         = false;
-        m_exception_type   = exception_type;
+        m_exception_type  = exception_type;
         m_exception_string.string = exception_string;
         m_contains         = false;
 #if DOCTEST_MSVC

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -670,12 +670,25 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-Contains::Contains(const char* in){
-    string = String(in);
+
+Contains::Contains() {
+    string = "";
 }
 
 Contains::~Contains(){
     string.~String();
+}
+
+Contains::Contains(const char* in){
+    string = String(in);
+}
+
+Contains::Contains(const Contains& other)
+: string(other.string) {}
+
+Contains& Contains::operator=(const Contains& other) {
+    string = other.string;
+    return *this;
 }
 
 bool Contains::checkWith(const String& full_string) const {

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -670,25 +670,12 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-
-Contains::Contains() {
-    string = "";
-}
-
-Contains::~Contains(){
-    string.~String();
-}
-
 Contains::Contains(const char* in){
     string = String(in);
 }
 
-Contains::Contains(const Contains& other)
-: string(other.string) {}
-
-Contains& Contains::operator=(const Contains& other) {
-    string = other.string;
-    return *this;
+Contains::~Contains(){
+    string.~String();
 }
 
 bool Contains::checkWith(const String& full_string) const {
@@ -1774,7 +1761,7 @@ namespace detail {
         m_failed           = true;
         m_threw            = false;
         m_threw_as         = false;
-        m_exception_type   = exception_type;
+        m_exception_type  = exception_type;
         m_exception_string.string = exception_string;
         m_contains         = false;
 #if DOCTEST_MSVC

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -670,12 +670,12 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-const char *String::compare(const Contains& other) const {
-    return strstr(c_str(), other.string.c_str());
-}
-
 Contains::Contains(const char* in){
     string = String(in);
+}
+
+bool Contains::checkWith(const String& full_string) const {
+    return strstr(full_string.c_str(), string.c_str()) != nullptr;
 }
 
 // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
@@ -683,8 +683,9 @@ String operator+(const String& lhs, const String& rhs) { return  String(lhs) += 
 
 // clang-format off
 bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
+bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
 bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
-bool operator!=(const String& lhs, const Contains& rhs) { return lhs.compare(rhs) == nullptr; }
+bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
 bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
 bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
 bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
@@ -1747,7 +1748,7 @@ namespace {
 } // namespace
 namespace detail {
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const char* exception_string) {
+                                 const char* exception_type, const String& exception_string) {
         m_test_case        = g_cs->currentTest;
         m_at               = at;
         m_file             = file;
@@ -1757,7 +1758,7 @@ namespace detail {
         m_threw            = false;
         m_threw_as         = false;
         m_exception_type   = exception_type;
-        m_exception_string = String(exception_string);
+        m_exception_string.string = exception_string;
         m_contains         = false;
 #if DOCTEST_MSVC
         if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
@@ -1766,7 +1767,7 @@ namespace detail {
     }
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, Contains exception_string) {
+                                 const char* exception_type, const Contains& exception_string) {
         m_test_case        = g_cs->currentTest;
         m_at               = at;
         m_file             = file;
@@ -1776,7 +1777,7 @@ namespace detail {
         m_threw            = false;
         m_threw_as         = false;
         m_exception_type   = exception_type;
-        m_exception_string = exception_string.string;
+        m_exception_string.contains = exception_string;
         m_contains         = true;
 #if DOCTEST_MSVC
         if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
@@ -1798,11 +1799,11 @@ namespace detail {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
         } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
-            m_failed = !m_threw_as || ( m_contains ? m_exception != Contains(m_exception_string.c_str()) : m_exception != String(m_exception_string));
+            m_failed = !m_threw_as || ( m_contains ? m_exception != m_exception_string.contains : m_exception != m_exception_string.string);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
         } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            m_failed = ( m_contains ? m_exception != Contains(m_exception_string.c_str()) : m_exception != String(m_exception_string));
+            m_failed = ( m_contains ? m_exception != m_exception_string.contains : m_exception != m_exception_string.string);
         } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
             m_failed = m_threw;
         }
@@ -2475,7 +2476,7 @@ namespace {
             if(rb.m_at & assertType::is_throws_as)
                 xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
             if(rb.m_at & assertType::is_throws_with)
-                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str());
             if((rb.m_at & assertType::is_normal) && !rb.m_threw)
                 xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
@@ -2521,7 +2522,8 @@ namespace {
         } else if((rb.m_at & assertType::is_throws_as) &&
                     (rb.m_at & assertType::is_throws_with)) { //!OCLINT
             s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string << "\", " << rb.m_exception_type << " ) " << Color::None;
+                << (rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str())
+                << "\", " << rb.m_exception_type << " ) " << Color::None;
             if(rb.m_threw) {
                 if(!rb.m_failed) {
                     s << "threw as expected!\n";
@@ -2542,7 +2544,8 @@ namespace {
         } else if(rb.m_at &
                     assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
             s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string << "\" ) " << Color::None
+                << (rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str())
+                << "\" ) " << Color::None
                 << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
                                                 "threw a DIFFERENT exception: ") :
                                 "did NOT throw at all!")

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -674,6 +674,10 @@ Contains::Contains(const char* in){
     string = String(in);
 }
 
+Contains::~Contains(){
+    string.~String();
+}
+
 bool Contains::checkWith(const String& full_string) const {
     return strstr(full_string.c_str(), string.c_str()) != nullptr;
 }

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -670,33 +670,32 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-Contains::Contains(const char* in){
-    string = String(in);
-}
+// NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
 
-Contains::~Contains(){
-    string.~String();
-}
+bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
+bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
+bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
+bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
+bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
+bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
+
+std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+
+Contains::Contains(const String& str) : string(str) { }
 
 bool Contains::checkWith(const String& full_string) const {
     return strstr(full_string.c_str(), string.c_str()) != nullptr;
 }
 
-// NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
+String toString(const Contains& in) {
+    return "Contains( " + in.string + " )";
+}
 
-// clang-format off
-bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
 bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
-bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
+bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
 bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
-bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
-bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
-bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
-bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-// clang-format on
-
-std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+bool operator!=(const Contains& lhs, const String& rhs) { return !lhs.checkWith(rhs); }
 
 namespace {
     void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
@@ -1750,44 +1749,26 @@ namespace {
     }
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 } // namespace
+
+AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+    const char* exception_type, const StringContains& exception_string)
+    : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
+    m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
+    m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
+
 namespace detail {
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const String& exception_string) {
-        m_test_case        = g_cs->currentTest;
-        m_at               = at;
-        m_file             = file;
-        m_line             = line;
-        m_expr             = expr;
-        m_failed           = true;
-        m_threw            = false;
-        m_threw_as         = false;
-        m_exception_type  = exception_type;
-        m_exception_string.string = exception_string;
-        m_contains         = false;
-#if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-#endif // MSVC
-    }
+                                 const char* exception_type, const String& exception_string)
+        : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const Contains& exception_string) {
-        m_test_case        = g_cs->currentTest;
-        m_at               = at;
-        m_file             = file;
-        m_line             = line;
-        m_expr             = expr;
-        m_failed           = true;
-        m_threw            = false;
-        m_threw_as         = false;
-        m_exception_type   = exception_type;
-        m_exception_string.contains = exception_string;
-        m_contains         = true;
-#if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-#endif // MSVC
-    }
+        const char* exception_type, const Contains& exception_string)
+        : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
     void ResultBuilder::setResult(const Result& res) {
         m_decomp = res.m_decomp;
@@ -1803,11 +1784,11 @@ namespace detail {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
         } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
-            m_failed = !m_threw_as || ( m_contains ? m_exception != m_exception_string.contains : m_exception != m_exception_string.string);
+            m_failed = !m_threw_as || !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
         } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            m_failed = ( m_contains ? m_exception != m_exception_string.contains : m_exception != m_exception_string.string);
+            m_failed = !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
             m_failed = m_threw;
         }
@@ -2480,7 +2461,7 @@ namespace {
             if(rb.m_at & assertType::is_throws_as)
                 xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
             if(rb.m_at & assertType::is_throws_with)
-                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str());
+                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
             if((rb.m_at & assertType::is_normal) && !rb.m_threw)
                 xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
@@ -2526,7 +2507,7 @@ namespace {
         } else if((rb.m_at & assertType::is_throws_as) &&
                     (rb.m_at & assertType::is_throws_with)) { //!OCLINT
             s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << (rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str())
+                << rb.m_exception_string.c_str()
                 << "\", " << rb.m_exception_type << " ) " << Color::None;
             if(rb.m_threw) {
                 if(!rb.m_failed) {
@@ -2548,7 +2529,7 @@ namespace {
         } else if(rb.m_at &
                     assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
             s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << (rb.m_contains ? rb.m_exception_string.contains.string.c_str() : rb.m_exception_string.string.c_str())
+                << rb.m_exception_string.c_str()
                 << "\" ) " << Color::None
                 << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
                                                 "threw a DIFFERENT exception: ") :

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -736,15 +736,6 @@ struct DOCTEST_INTERFACE TestCaseData
 
 struct DOCTEST_INTERFACE AssertData
 {
-    union StringContains {
-        String string;
-        Contains contains;
-
-        StringContains()
-            : string("") {}
-
-        ~StringContains() {}
-    };
     // common - for all asserts
     const TestCaseData* m_test_case;
     assertType::Enum    m_at;
@@ -763,16 +754,14 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool           m_threw_as;
     const char*    m_exception_type;
-    StringContains m_exception_string;
-    bool           m_contains;
+    union StringContains {
+        String string;
+        Contains contains;
 
-    ~AssertData() {
-        if (m_contains) {
-            m_exception_string.contains.~Contains();
-        } else {
-            m_exception_string.string.~String();
+        ~StringContains() {
         }
-   }
+    } m_exception_string = { String("") };
+    bool           m_contains;
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -580,14 +580,9 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-
-    Contains();
-    ~Contains();
-    
     explicit Contains(const char* string);
-    
-    explicit Contains(const Contains& other);
-    Contains& operator=(const Contains& other);
+
+    ~Contains();
 
     bool checkWith(const String& other) const;
 
@@ -761,31 +756,15 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool           m_threw_as;
     const char*    m_exception_type;
-    union StringContains {
+    struct StringContains {
         String string;
         Contains contains;
 
-        ~StringContains() {
-        }
-    } m_exception_string = { String("") };
+        StringContains()
+            : string(""), contains("") {}
+
+    } m_exception_string;
     bool           m_contains;
-
-   // AssertData(const AssertData& assert_data) 
-   // : m_contains(assert_data.m_contains) {
-   //     if(assert_data.m_contains) {
-   //         m_exception_string.contains = assert_data.m_exception_string.contains;
-   //     } else {
-   //         m_exception_string.string = assert_data.m_exception_string.string;
-   //     }
-   //}
-
-    ~AssertData() {
-        if (m_contains) {
-            m_exception_string.contains.~Contains();
-        } else {
-            m_exception_string.string.~String();
-        }
-    }
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -762,6 +762,23 @@ struct DOCTEST_INTERFACE AssertData
         }
     } m_exception_string = { String("") };
     bool           m_contains;
+
+   // AssertData(const AssertData& assert_data) 
+   // : m_contains(assert_data.m_contains) {
+   //     if(assert_data.m_contains) {
+   //         m_exception_string.contains = assert_data.m_exception_string.contains;
+   //     } else {
+   //         m_exception_string.string = assert_data.m_exception_string.string;
+   //     }
+   //}
+
+    ~AssertData() {
+        if (m_contains) {
+            m_exception_string.contains.~Contains();
+        } else {
+            m_exception_string.string.~String();
+        }
+    }
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -578,29 +578,32 @@ public:
     int compare(const String& other, bool no_case = false) const;
 };
 
-class DOCTEST_INTERFACE Contains {
-public:
-    explicit Contains(const char* string);
-
-    ~Contains();
-
-    bool checkWith(const String& other) const;
-
-    String string;
-};
-
 DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
-DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
 DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
-DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
 DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+
+class DOCTEST_INTERFACE Contains {
+public:
+    explicit Contains(const String& string);
+
+    bool checkWith(const String& other) const;
+
+    String string;
+};
+
+DOCTEST_INTERFACE String toString(const Contains& in);
+
+DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator==(const Contains& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains& lhs, const String& rhs);
 
 namespace Color {
     enum Enum
@@ -756,15 +759,25 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool           m_threw_as;
     const char*    m_exception_type;
-    struct StringContains {
-        String string;
-        Contains contains;
+    class DOCTEST_INTERFACE StringContains {
+        private:
+            Contains content;
+            bool isContains;
 
-        StringContains()
-            : string(""), contains("") {}
+        public:
+            StringContains() : content(String()), isContains(false) { }
+            StringContains(const String& str) : content(str), isContains(false) { }
+            StringContains(const Contains& cntn) : content(cntn), isContains(true) { }
 
+            bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
+
+            operator const String&() const { return content.string; }
+
+            const char* c_str() const { return content.string.c_str(); }
     } m_exception_string;
-    bool           m_contains;
+
+    AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+        const char* exception_type, const StringContains& exception_string);
 };
 
 struct DOCTEST_INTERFACE MessageData

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -580,9 +580,14 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const char* string);\
 
+    Contains();
     ~Contains();
+    
+    explicit Contains(const char* string);
+    
+    explicit Contains(const Contains& other);
+    Contains& operator=(const Contains& other);
 
     bool checkWith(const String& other) const;
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -494,6 +494,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 namespace doctest {
 
+class Contains;
+
 DOCTEST_INTERFACE extern bool is_running_in_test;
 
 // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
@@ -576,12 +578,21 @@ public:
 
     int compare(const char* other, bool no_case = false) const;
     int compare(const String& other, bool no_case = false) const;
+    const char *compare(const Contains& other) const;
+};
+
+class DOCTEST_INTERFACE Contains {
+public:
+    Contains(const char* string);
+
+    String string;
 };
 
 DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
 DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
@@ -743,7 +754,8 @@ struct DOCTEST_INTERFACE AssertData
     // for specific exception-related asserts
     bool        m_threw_as;
     const char* m_exception_type;
-    const char* m_exception_string;
+    String      m_exception_string;
+    bool        m_contains;
 };
 
 struct DOCTEST_INTERFACE MessageData
@@ -1517,6 +1529,9 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
     {
         ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
                       const char* exception_type = "", const char* exception_string = "");
+
+        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                      const char* exception_type, Contains exception_string);
 
         void setResult(const Result& res);
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -580,7 +580,9 @@ public:
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const char* string);
+    explicit Contains(const char* string);\
+
+    ~Contains();
 
     bool checkWith(const String& other) const;
 

--- a/examples/all_features/assertion_macros.cpp
+++ b/examples/all_features/assertion_macros.cpp
@@ -76,6 +76,10 @@ TEST_CASE("WARN level of asserts don't fail the test case") {
     WARN_NOTHROW(throw_if(true, 0));
 
     WARN_EQ(1, 0);
+    doctest::String myStr = doctest::String("Hello world, how are you doing? Well, nice to meet you, Goodbye!");
+    WARN_EQ(myStr, doctest::Contains("Hello"));
+    WARN(myStr == doctest::Contains("Goodbye"));
+    WARN(myStr != doctest::Contains("goodbye"));
     WARN_UNARY(0);
     WARN_UNARY_FALSE(1);
 }
@@ -91,6 +95,10 @@ TEST_CASE("CHECK level of asserts fail the test case but don't abort it") {
     CHECK_NOTHROW(throw_if(true, 0));
 
     CHECK_EQ(1, 0);
+    doctest::String myStr = doctest::String("Hello world, how are you doing? Well, nice to meet you, Goodbye!");
+    CHECK_EQ(myStr, doctest::Contains("Hello"));
+    CHECK(myStr == doctest::Contains("Goodbye"));
+    CHECK(myStr != doctest::Contains("goodbye"));
     CHECK_UNARY(0);
     CHECK_UNARY_FALSE(1);
 

--- a/examples/all_features/assertion_macros.cpp
+++ b/examples/all_features/assertion_macros.cpp
@@ -38,8 +38,11 @@ TEST_CASE("exceptions-related macros") {
     CHECK_THROWS_AS(throw_if(false, 0), int); // fails
 
     CHECK_THROWS_WITH(throw_if(true, "whops!"), "whops! no match!"); // fails
+    CHECK_THROWS_WITH(throw_if(true, "whops! does it match?"), doctest::Contains("whops!"));
+    CHECK_THROWS_WITH(throw_if(true, "whops! does it match?"), doctest::Contains("whops! no match!")); // fails
     CHECK_THROWS_WITH_AS(throw_if(true, "whops!"), "whops! no match!", bool); // fails
     CHECK_THROWS_WITH_AS(throw_if(true, "whops!"), "whops!", int); // fails
+    CHECK_THROWS_WITH_AS(throw_if(true, "whops! does it match?"), doctest::Contains("whops! no match!"), int); // fails
 
     CHECK_NOTHROW(throw_if(true, 0)); // fails
     CHECK_NOTHROW(throw_if(false, 0));

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -151,6 +151,8 @@ TEST_CASE("all asserts should fail and show how the objects get stringified") {
     CHECK(doctest::IsNaN<float>(std::numeric_limits<float>::infinity()));
     // can't test actual nan because it's implementation defined
 
+    CHECK("a" == doctest::Contains("aaa"));
+
     // lets see if this exception gets translated
     throw_if(true, bla1);
 }

--- a/examples/all_features/test_output/assertion_macros.cpp.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp.txt
@@ -252,6 +252,6 @@ assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH( throw_if(true, 2), "1" ) thre
 
 ===============================================================================
 [doctest] test cases: 23 |  4 passed | 19 failed |
-[doctest] assertions: 95 | 45 passed | 50 failed |
+[doctest] assertions: 98 | 48 passed | 50 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/assertion_macros.cpp.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp.txt
@@ -20,9 +20,13 @@ assertion_macros.cpp(0): ERROR: CHECK_THROWS_AS( throw_if(false, 0), int ) did N
 
 assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH( throw_if(true, "whops!"), "whops! no match!" ) threw a DIFFERENT exception: "whops!"
 
+assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH( throw_if(true, "whops! does it match?"), "whops! no match!" ) threw a DIFFERENT exception: "whops! does it match?"
+
 assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH_AS( throw_if(true, "whops!"), "whops! no match!", bool ) threw a DIFFERENT exception! (contents: "whops!")
 
 assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH_AS( throw_if(true, "whops!"), "whops!", int ) threw a DIFFERENT exception! (contents: "whops!")
+
+assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH_AS( throw_if(true, "whops! does it match?"), "whops! no match!", int ) threw a DIFFERENT exception! (contents: "whops! does it match?")
 
 assertion_macros.cpp(0): ERROR: CHECK_NOTHROW( throw_if(true, 0) ) THREW exception: "0"
 
@@ -248,6 +252,6 @@ assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH( throw_if(true, 2), "1" ) thre
 
 ===============================================================================
 [doctest] test cases: 23 |  4 passed | 19 failed |
-[doctest] assertions: 92 | 44 passed | 48 failed |
+[doctest] assertions: 95 | 45 passed | 50 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/assertion_macros.cpp_junit.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="0" failures="63" tests="95">
+  <testsuite name="all_features" errors="0" failures="63" tests="98">
     <testcase classname="assertion_macros.cpp" name="normal macros" status="run">
       <failure type="CHECK">
 assertion_macros.cpp(0):

--- a/examples/all_features/test_output/assertion_macros.cpp_junit.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="0" failures="61" tests="92">
+  <testsuite name="all_features" errors="0" failures="63" tests="95">
     <testcase classname="assertion_macros.cpp" name="normal macros" status="run">
       <failure type="CHECK">
 assertion_macros.cpp(0):
@@ -36,6 +36,11 @@ assertion_macros.cpp(0):
 CHECK_THROWS_WITH( throw_if(true, "whops!"), "whops! no match!" ) threw a DIFFERENT exception: "whops!"
 
       </failure>
+      <failure type="CHECK_THROWS_WITH">
+assertion_macros.cpp(0):
+CHECK_THROWS_WITH( throw_if(true, "whops! does it match?"), "whops! no match!" ) threw a DIFFERENT exception: "whops! does it match?"
+
+      </failure>
       <failure type="CHECK_THROWS_WITH_AS">
 assertion_macros.cpp(0):
 CHECK_THROWS_WITH_AS( throw_if(true, "whops!"), "whops! no match!", bool ) threw a DIFFERENT exception! (contents: "whops!")
@@ -44,6 +49,11 @@ CHECK_THROWS_WITH_AS( throw_if(true, "whops!"), "whops! no match!", bool ) threw
       <failure type="CHECK_THROWS_WITH_AS">
 assertion_macros.cpp(0):
 CHECK_THROWS_WITH_AS( throw_if(true, "whops!"), "whops!", int ) threw a DIFFERENT exception! (contents: "whops!")
+
+      </failure>
+      <failure type="CHECK_THROWS_WITH_AS">
+assertion_macros.cpp(0):
+CHECK_THROWS_WITH_AS( throw_if(true, "whops! does it match?"), "whops! no match!", int ) threw a DIFFERENT exception! (contents: "whops! does it match?")
 
       </failure>
       <failure type="CHECK_NOTHROW">

--- a/examples/all_features/test_output/assertion_macros.cpp_xml.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp_xml.txt
@@ -384,7 +384,7 @@
           reached!
         </Text>
       </Message>
-      <OverallResultsAsserts successes="0" failures="11" test_case_success="false"/>
+      <OverallResultsAsserts successes="3" failures="11" test_case_success="false"/>
     </TestCase>
     <TestCase name="REQUIRE level of asserts fail and abort the test case - 1" filename="assertion_macros.cpp" line="0">
       <Expression success="false" type="REQUIRE" filename="assertion_macros.cpp" line="0">
@@ -684,7 +684,7 @@
       <OverallResultsAsserts successes="0" failures="9" test_case_success="false"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="45" failures="50"/>
+  <OverallResultsAsserts successes="48" failures="50"/>
   <OverallResultsTestCases successes="4" failures="19"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/assertion_macros.cpp_xml.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp_xml.txt
@@ -60,6 +60,17 @@
           whops! no match!
         </ExpectedExceptionString>
       </Expression>
+      <Expression success="false" type="CHECK_THROWS_WITH" filename="assertion_macros.cpp" line="0">
+        <Original>
+          throw_if(true, "whops! does it match?")
+        </Original>
+        <Exception>
+          "whops! does it match?"
+        </Exception>
+        <ExpectedExceptionString>
+          whops! no match!
+        </ExpectedExceptionString>
+      </Expression>
       <Expression success="false" type="CHECK_THROWS_WITH_AS" filename="assertion_macros.cpp" line="0">
         <Original>
           throw_if(true, "whops!")
@@ -88,6 +99,20 @@
           whops!
         </ExpectedExceptionString>
       </Expression>
+      <Expression success="false" type="CHECK_THROWS_WITH_AS" filename="assertion_macros.cpp" line="0">
+        <Original>
+          throw_if(true, "whops! does it match?")
+        </Original>
+        <Exception>
+          "whops! does it match?"
+        </Exception>
+        <ExpectedException>
+          int
+        </ExpectedException>
+        <ExpectedExceptionString>
+          whops! no match!
+        </ExpectedExceptionString>
+      </Expression>
       <Expression success="false" type="CHECK_NOTHROW" filename="assertion_macros.cpp" line="0">
         <Original>
           throw_if(true, 0)
@@ -96,7 +121,7 @@
           "0"
         </Exception>
       </Expression>
-      <OverallResultsAsserts successes="3" failures="7" test_case_success="false"/>
+      <OverallResultsAsserts successes="4" failures="9" test_case_success="false"/>
     </TestCase>
     <TestCase name="exceptions-related macros for std::exception" filename="assertion_macros.cpp" line="0">
       <Expression success="false" type="CHECK_THROWS" filename="assertion_macros.cpp" line="0">
@@ -659,7 +684,7 @@
       <OverallResultsAsserts successes="0" failures="9" test_case_success="false"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="44" failures="48"/>
+  <OverallResultsAsserts successes="45" failures="50"/>
   <OverallResultsTestCases successes="4" failures="19"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -33,6 +33,9 @@ stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<double>(0.5) ) is NOT corre
 stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<float>(std::numeric_limits<float>::infinity()) ) is NOT correct!
   values: CHECK( inf )
 
+stringification.cpp(0): ERROR: CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
+  values: CHECK( a == Contains( aaa ) )
+
 stringification.cpp(0): ERROR: test case THREW exception: MyTypeInherited<int>(5, 4)
 
 ===============================================================================
@@ -42,7 +45,7 @@ TEST CASE:  a test case that registers an exception translator for int and then 
 stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
-[doctest] test cases: 2 | 0 passed | 2 failed |
-[doctest] assertions: 9 | 0 passed | 9 failed |
+[doctest] test cases:  2 | 0 passed |  2 failed |
+[doctest] assertions: 10 | 0 passed | 10 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="9" tests="9">
+  <testsuite name="all_features" errors="2" failures="10" tests="10">
     <testcase classname="stringification.cpp" name="all asserts should fail and show how the objects get stringified" status="run">
       <failure message="Foo{} == Foo{}" type="CHECK">
 stringification.cpp(0):
@@ -57,6 +57,12 @@ CHECK( doctest::IsNaN&lt;double>(0.5) ) is NOT correct!
 stringification.cpp(0):
 CHECK( doctest::IsNaN&lt;float>(std::numeric_limits&lt;float>::infinity()) ) is NOT correct!
   values: CHECK( inf )
+
+      </failure>
+      <failure message="a == Contains( aaa )" type="CHECK">
+stringification.cpp(0):
+CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
+  values: CHECK( a == Contains( aaa ) )
 
       </failure>
       <error message="exception">

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -84,10 +84,18 @@
           inf
         </Expanded>
       </Expression>
+      <Expression success="false" type="CHECK" filename="stringification.cpp" line="0">
+        <Original>
+          "a" == doctest::Contains("aaa")
+        </Original>
+        <Expanded>
+          a == Contains( aaa )
+        </Expanded>
+      </Expression>
       <Exception crash="false">
         MyTypeInherited&lt;int>(5, 4)
       </Exception>
-      <OverallResultsAsserts successes="0" failures="9" test_case_success="false"/>
+      <OverallResultsAsserts successes="0" failures="10" test_case_success="false"/>
     </TestCase>
     <TestCase name="a test case that registers an exception translator for int and then throws one" filename="stringification.cpp" line="0">
       <Exception crash="false">
@@ -96,7 +104,7 @@
       <OverallResultsAsserts successes="0" failures="0" test_case_success="false"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="0" failures="9"/>
+  <OverallResultsAsserts successes="0" failures="10"/>
   <OverallResultsTestCases successes="0" failures="2"/>
 </doctest>
 Program code.


### PR DESCRIPTION
## Description
This is an implementation of what was suggested in #619. It implements a `Contains` class for the `CHECK_THROWS_WITH` (and checks in general). This allows for checking whether the throw message contains a certain string, similar to what Catch2 does. 

I first tried the union approach as suggested in the related issue, but I ran in a host of issues, including that due to non-trivial members, the default constructors and operators where deleted. I found especially the copy constructor/operator= hard to replace, since it requires knowledge about what member of the union is being used. I now use a bool to check whether it is a contains or not. This approach seems easier to me, and I can't see significant downsides of this implementation, but I am open to further suggestions.

I have not implemented test yet, because I would first like to know if this approach is acceptable, but it works well as a replacement for catch2 on my code base. I tried to format the cod with `clang-format -style=file -i doctest/parts/doctest*`, but it also changes the format of lines I haven't changed in this pull request.

## GitHub Issues
closes  #619.
