### PR TITLE
Fix properties not being passed in doctest_discover_tests

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -105,8 +105,8 @@ foreach(line ${output})
     "${prefix}${test}${suffix}"
     PROPERTIES
     WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-    LABELS ${labels}
     ${properties}
+    LABELS ${labels}
   )
   unset(labels)
   list(APPEND tests "${prefix}${test}${suffix}")


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

This changes the position of the LABELS property so that an empty value for `${labels}` doesn't break other PROPERTY values set in `${properties}`.

I tried putting quotes around `"${labels}"`, but still couldn't successfully set an environment variable.

Here's the repo I created to test this change. 
https://github.com/quantumsteve/doctest_example

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Fixes #621