### PR TITLE
re-re-remove overly restrictive minimum version of meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('doctest', ['cpp'], version: '2.4.8', meson_version:'>=0.50')
+project('doctest', ['cpp'], version: '2.4.8')
 
 doctest_dep = declare_dependency(include_directories: include_directories('doctest'))
 

--- a/scripts/update_stuff.py
+++ b/scripts/update_stuff.py
@@ -34,7 +34,7 @@ readme.close()
 meson_contents = ""
 for line in fileinput.input(["../meson.build"]):
     if line.startswith("project('doctest'"):
-        meson_contents += "project('doctest', ['cpp'], version: '" + version + "', meson_version:'>=0.50')\n"
+        meson_contents += "project('doctest', ['cpp'], version: '" + version + "')\n"
     else:
         meson_contents += line
 


### PR DESCRIPTION
Despite being removed a couple of times in commits 6adc79f864138ddf25daa8ffd01fcb3f622cec6f and 208310134ba0ed783e5d979e8111021ce6a5acb3 this kept on getting re-added by the automatic update script. Remove it more thoroughly this time.