### PR TITLE
Fix #508

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -3081,10 +3081,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <cfloat>
 #include <cctype>
 #include <cstdint>
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 #include <string>
-#endif // VS 2019
 
 #ifdef DOCTEST_PLATFORM_MAC
 #include <sys/types.h>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -586,6 +586,8 @@ public:
     String(const char* in);
     String(const char* in, size_type in_size);
 
+    String(const std::string& in);
+
     String(std::istream& in, size_type in_size);
 
     String(const String& other);
@@ -3528,6 +3530,9 @@ String::String(const char* in)
 String::String(const char* in, size_type in_size) {
     memcpy(allocate(in_size), in, in_size);
 }
+
+String::String(const std::string& in)
+    : String(in.c_str(), in.length()) {}
 
 String::String(std::istream& in, size_type in_size) {
     in.read(allocate(in_size), in_size);

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -498,14 +498,11 @@ class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream;
 template <class... Types>
 class tuple;
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>
 class allocator;
 template <class Elem, class Traits, class Alloc>
 class basic_string;
 using string = basic_string<char, char_traits<char>, allocator<char>>;
-#endif // VS 2019
 } // namespace std
 
 DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -543,6 +543,9 @@ String::String(const char* in, size_type in_size) {
     memcpy(allocate(in_size), in, in_size);
 }
 
+String::String(const std::string& in)
+    : String(in.c_str(), in.length()) {}
+
 String::String(std::istream& in, size_type in_size) {
     in.read(allocate(in_size), in_size);
 }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -495,14 +495,11 @@ class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream;
 template <class... Types>
 class tuple;
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>
 class allocator;
 template <class Elem, class Traits, class Alloc>
 class basic_string;
 using string = basic_string<char, char_traits<char>, allocator<char>>;
-#endif // VS 2019
 } // namespace std
 
 DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -583,6 +583,8 @@ public:
     String(const char* in);
     String(const char* in, size_type in_size);
 
+    String(const std::string& in);
+
     String(std::istream& in, size_type in_size);
 
     String(const String& other);

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -247,7 +247,7 @@ TEST_CASE("a test case that registers an exception translator for int and then t
 
 namespace App {
     struct Foo { };
-    std::string toString(Foo*) { return "Foo"; }
+    static std::string toString(Foo*) { return "Foo"; }
 }
 
 TEST_CASE("toString std::string return") {

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -244,3 +244,15 @@ TEST_CASE("a test case that registers an exception translator for int and then t
 
     throw_if(true, 5);
 }
+
+namespace App {
+    struct Foo { };
+    std::string toString(Foo*) { return "Foo"; }
+}
+
+TEST_CASE("toString std::string return") {
+    App::Foo foo;
+    CHECK(&foo != nullptr);
+    CHECK_NE(&foo, nullptr);
+    CHECK(&foo);
+}

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 102 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 103 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 100 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 102 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -146,6 +146,6 @@
     <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="100"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="102"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -129,6 +129,7 @@
     <TestCase name="test case should fail even though the last subcase passes" filename="subcases.cpp" line="0" skipped="true"/>
     <TestCase name="third party asserts can report failures to doctest" filename="logging.cpp" line="0" skipped="true"/>
     <TestCase name="threads..." filename="concurrency.cpp" line="0" skipped="true"/>
+    <TestCase name="toString std::string return" filename="stringification.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite name="skipped test cases">
     <TestCase name="unskipped" filename="test_cases_and_suites.cpp" line="0" description="this test has overridden its skip decorator" skipped="true"/>
@@ -146,6 +147,6 @@
     <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="102"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="103"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/no_multi_lane_atomics.txt
+++ b/examples/all_features/test_output/no_multi_lane_atomics.txt
@@ -922,7 +922,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  82 |  31 passed |  51 failed |
-[doctest] assertions: 224 | 105 passed | 119 failed |
+[doctest] test cases:  83 |  32 passed |  51 failed |
+[doctest] assertions: 227 | 108 passed | 119 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multi_lane_atomics.txt
+++ b/examples/all_features/test_output/no_multi_lane_atomics.txt
@@ -214,8 +214,12 @@ logging.cpp(0): ERROR: test case THREW exception: 0
 stringification.cpp(0):
 TEST CASE:  all asserts should fail and show how the objects get stringified
 
+stringification.cpp(0): MESSAGE: Foo{}
+
 stringification.cpp(0): ERROR: CHECK( f1 == f2 ) is NOT correct!
   values: CHECK( Foo{} == Foo{} )
+
+stringification.cpp(0): MESSAGE: omg
 
 stringification.cpp(0): ERROR: CHECK( dummy == "tralala" ) is NOT correct!
   values: CHECK( omg == tralala )
@@ -223,11 +227,15 @@ stringification.cpp(0): ERROR: CHECK( dummy == "tralala" ) is NOT correct!
 stringification.cpp(0): ERROR: CHECK( "tralala" == dummy ) is NOT correct!
   values: CHECK( tralala == omg )
 
+stringification.cpp(0): MESSAGE: [1, 2, 3]
+
 stringification.cpp(0): ERROR: CHECK( vec1 == vec2 ) is NOT correct!
   values: CHECK( [1, 2, 3] == [1, 2, 4] )
 
+stringification.cpp(0): MESSAGE: [1, 42, 3]
+
 stringification.cpp(0): ERROR: CHECK( lst_1 == lst_2 ) is NOT correct!
-  values: CHECK( [1, 42, 3, ] == [1, 2, 666, ] )
+  values: CHECK( [1, 42, 3] == [1, 2, 666] )
 
 stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
   values: CHECK( MyOtherType: 42 == MyOtherType: 666 )
@@ -237,12 +245,6 @@ stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
   values: CHECK( MyOtherType: 42 == MyOtherType: 666 )
   logged: s1=MyOtherType: 42 s2=MyOtherType: 666
           MyOtherType: 42 is not really MyOtherType: 666
-
-stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<double>(0.5) ) is NOT correct!
-  values: CHECK( 0.5 )
-
-stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<float>(std::numeric_limits<float>::infinity()) ) is NOT correct!
-  values: CHECK( inf )
 
 stringification.cpp(0): ERROR: CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
   values: CHECK( a == Contains( aaa ) )
@@ -581,24 +583,57 @@ subcases.cpp(0): FATAL ERROR:
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<Custom name test>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<Other custom name>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<TypePair<bool, int>>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
+
+===============================================================================
+stringification.cpp(0):
+TEST CASE:  no headers
+
+stringification.cpp(0): MESSAGE: 1as
+
+stringification.cpp(0): ERROR: CHECK( chs == nullptr ) is NOT correct!
+  values: CHECK( 1as == nullptr )
+
+stringification.cpp(0): MESSAGE: 1as
+
+stringification.cpp(0): ERROR: CHECK( "1as" == nullptr ) is NOT correct!
+  values: CHECK( 1as == nullptr )
+
+stringification.cpp(0): MESSAGE: [0, 1, 1, 2, 3, 5, 8, 13]
+
+stringification.cpp(0): ERROR: CHECK( ints == nullptr ) is NOT correct!
+  values: CHECK( [0, 1, 1, 2, 3, 5, 8, 13] == nullptr )
+
+stringification.cpp(0): MESSAGE: [0, 1, 1, 2, 3, 5, 8, 13]
+
+stringification.cpp(0): MESSAGE: nullptr
+
+stringification.cpp(0): ERROR: CHECK( cnptr != nullptr ) is NOT correct!
+  values: CHECK( nullptr != nullptr )
+
+stringification.cpp(0): MESSAGE: 0
+
+stringification.cpp(0): ERROR: CHECK( A == C ) is NOT correct!
+  values: CHECK( 0 == 100 )
+
+stringification.cpp(0): MESSAGE: int
 
 ===============================================================================
 assertion_macros.cpp(0):
@@ -617,6 +652,16 @@ TEST CASE:  normal test in a test suite from a decorator
 test_cases_and_suites.cpp(0): MESSAGE: failing because of the timeout decorator!
 
 Test case exceeded time limit of 0.000001!
+===============================================================================
+stringification.cpp(0):
+TEST CASE:  operator<<
+
+stringification.cpp(0): MESSAGE: A
+
+stringification.cpp(0): MESSAGE: B
+
+stringification.cpp(0): MESSAGE: C
+
 ===============================================================================
 test_cases_and_suites.cpp(0):
 TEST SUITE: scoped test suite
@@ -877,7 +922,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  80 |  30 passed |  50 failed |
-[doctest] assertions: 216 | 100 passed | 116 failed |
+[doctest] test cases:  82 |  31 passed |  51 failed |
+[doctest] assertions: 224 | 105 passed | 119 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multithreading.txt
+++ b/examples/all_features/test_output/no_multithreading.txt
@@ -922,7 +922,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  82 |  31 passed |  51 failed |
-[doctest] assertions: 224 | 105 passed | 119 failed |
+[doctest] test cases:  83 |  32 passed |  51 failed |
+[doctest] assertions: 227 | 108 passed | 119 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multithreading.txt
+++ b/examples/all_features/test_output/no_multithreading.txt
@@ -214,8 +214,12 @@ logging.cpp(0): ERROR: test case THREW exception: 0
 stringification.cpp(0):
 TEST CASE:  all asserts should fail and show how the objects get stringified
 
+stringification.cpp(0): MESSAGE: Foo{}
+
 stringification.cpp(0): ERROR: CHECK( f1 == f2 ) is NOT correct!
   values: CHECK( Foo{} == Foo{} )
+
+stringification.cpp(0): MESSAGE: omg
 
 stringification.cpp(0): ERROR: CHECK( dummy == "tralala" ) is NOT correct!
   values: CHECK( omg == tralala )
@@ -223,11 +227,15 @@ stringification.cpp(0): ERROR: CHECK( dummy == "tralala" ) is NOT correct!
 stringification.cpp(0): ERROR: CHECK( "tralala" == dummy ) is NOT correct!
   values: CHECK( tralala == omg )
 
+stringification.cpp(0): MESSAGE: [1, 2, 3]
+
 stringification.cpp(0): ERROR: CHECK( vec1 == vec2 ) is NOT correct!
   values: CHECK( [1, 2, 3] == [1, 2, 4] )
 
+stringification.cpp(0): MESSAGE: [1, 42, 3]
+
 stringification.cpp(0): ERROR: CHECK( lst_1 == lst_2 ) is NOT correct!
-  values: CHECK( [1, 42, 3, ] == [1, 2, 666, ] )
+  values: CHECK( [1, 42, 3] == [1, 2, 666] )
 
 stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
   values: CHECK( MyOtherType: 42 == MyOtherType: 666 )
@@ -237,12 +245,6 @@ stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
   values: CHECK( MyOtherType: 42 == MyOtherType: 666 )
   logged: s1=MyOtherType: 42 s2=MyOtherType: 666
           MyOtherType: 42 is not really MyOtherType: 666
-
-stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<double>(0.5) ) is NOT correct!
-  values: CHECK( 0.5 )
-
-stringification.cpp(0): ERROR: CHECK( doctest::IsNaN<float>(std::numeric_limits<float>::infinity()) ) is NOT correct!
-  values: CHECK( inf )
 
 stringification.cpp(0): ERROR: CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
   values: CHECK( a == Contains( aaa ) )
@@ -581,24 +583,57 @@ subcases.cpp(0): FATAL ERROR:
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<Custom name test>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<Other custom name>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
 
 ===============================================================================
 templated_test_cases.cpp(0):
-TEST CASE:  multiple types<>
+TEST CASE:  multiple types<TypePair<bool, int>>
 
 templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
+
+===============================================================================
+stringification.cpp(0):
+TEST CASE:  no headers
+
+stringification.cpp(0): MESSAGE: 1as
+
+stringification.cpp(0): ERROR: CHECK( chs == nullptr ) is NOT correct!
+  values: CHECK( 1as == nullptr )
+
+stringification.cpp(0): MESSAGE: 1as
+
+stringification.cpp(0): ERROR: CHECK( "1as" == nullptr ) is NOT correct!
+  values: CHECK( 1as == nullptr )
+
+stringification.cpp(0): MESSAGE: [0, 1, 1, 2, 3, 5, 8, 13]
+
+stringification.cpp(0): ERROR: CHECK( ints == nullptr ) is NOT correct!
+  values: CHECK( [0, 1, 1, 2, 3, 5, 8, 13] == nullptr )
+
+stringification.cpp(0): MESSAGE: [0, 1, 1, 2, 3, 5, 8, 13]
+
+stringification.cpp(0): MESSAGE: nullptr
+
+stringification.cpp(0): ERROR: CHECK( cnptr != nullptr ) is NOT correct!
+  values: CHECK( nullptr != nullptr )
+
+stringification.cpp(0): MESSAGE: 0
+
+stringification.cpp(0): ERROR: CHECK( A == C ) is NOT correct!
+  values: CHECK( 0 == 100 )
+
+stringification.cpp(0): MESSAGE: int
 
 ===============================================================================
 assertion_macros.cpp(0):
@@ -617,6 +652,16 @@ TEST CASE:  normal test in a test suite from a decorator
 test_cases_and_suites.cpp(0): MESSAGE: failing because of the timeout decorator!
 
 Test case exceeded time limit of 0.000001!
+===============================================================================
+stringification.cpp(0):
+TEST CASE:  operator<<
+
+stringification.cpp(0): MESSAGE: A
+
+stringification.cpp(0): MESSAGE: B
+
+stringification.cpp(0): MESSAGE: C
+
 ===============================================================================
 test_cases_and_suites.cpp(0):
 TEST SUITE: scoped test suite
@@ -877,7 +922,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  80 |  30 passed |  50 failed |
-[doctest] assertions: 216 | 100 passed | 116 failed |
+[doctest] test cases:  82 |  31 passed |  51 failed |
+[doctest] assertions: 224 | 105 passed | 119 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -90,7 +90,7 @@ TEST CASE:  a test case that registers an exception translator for int and then 
 stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
-[doctest] test cases:  4 | 1 passed |  3 failed |
-[doctest] assertions: 18 | 5 passed | 13 failed |
+[doctest] test cases:  5 | 2 passed |  3 failed |
+[doctest] assertions: 21 | 8 passed | 13 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="13" tests="18">
+  <testsuite name="all_features" errors="2" failures="13" tests="21">
     <testcase classname="stringification.cpp" name="operator&lt;&lt;" status="run"/>
     <testcase classname="stringification.cpp" name="no headers" status="run">
       <failure message="1as == nullptr" type="CHECK">
@@ -95,6 +95,7 @@ CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
         5
       </error>
     </testcase>
+    <testcase classname="stringification.cpp" name="toString std::string return" status="run"/>
   </testsuite>
 </testsuites>
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -203,8 +203,11 @@
       </Exception>
       <OverallResultsAsserts successes="0" failures="0" test_case_success="false"/>
     </TestCase>
+    <TestCase name="toString std::string return" filename="stringification.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="5" failures="13"/>
-  <OverallResultsTestCases successes="1" failures="3"/>
+  <OverallResultsAsserts successes="8" failures="13"/>
+  <OverallResultsTestCases successes="2" failures="3"/>
 </doctest>
 Program code.


### PR DESCRIPTION
Simply adding a `std::string` ctor to `doctest::String` does the trick very well! Now that we're forward declaring `std::string` anyways.