### PR TITLE
Avoid static init problem in insufficient_procs() (MPI)

### DIFF
--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -93,6 +93,7 @@ namespace doctest {
 extern std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
 extern int nb_test_cases_skipped_insufficient_procs;
 extern int world_size_before_init;
+int mpi_comm_world_size();
 
 int mpi_init_thread(int argc, char *argv[], int required_thread_support);
 void mpi_finalize();
@@ -113,7 +114,7 @@ void execute_mpi_test_case(F func) {
 
 inline bool
 insufficient_procs(int test_nb_procs) {
-  bool insufficient = test_nb_procs>world_size_before_init;
+  bool insufficient = test_nb_procs>mpi_comm_world_size();
   if (insufficient) {
     ++nb_test_cases_skipped_insufficient_procs;
   }

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -114,7 +114,8 @@ void execute_mpi_test_case(F func) {
 
 inline bool
 insufficient_procs(int test_nb_procs) {
-  bool insufficient = test_nb_procs>mpi_comm_world_size();
+  static const int world_size = mpi_comm_world_size();
+  bool insufficient = test_nb_procs>world_size;
   if (insufficient) {
     ++nb_test_cases_skipped_insufficient_procs;
   }


### PR DESCRIPTION
## Description
Reverses an incidental change that came along with #623. That PR gives a proper initial value for `world_size_before_init`. Incidentally, it also adds an evaluation of this variable possibly prior to its initialization. (The function `insufficient_procs()` is called before entering `main()`). For me it caused all MPI_TEST_CASE to be marked as skipped, even when the actual process count was sufficient. The present PR fixes this problem.