### PR TITLE
Reorganising the MPI code and adding a default main() entry to the MPI

### DIFF
--- a/doc/markdown/extensions.md
+++ b/doc/markdown/extensions.md
@@ -64,6 +64,16 @@ mpirun -np 2 unit_test_executable.exe
 
 ```doctest::mpi_init_thread()``` must be called before running the unit tests, and ```doctest::mpi_finalize()``` at the end of the program. Also, using the default console reporter will result in each process writing everything in the same place, which is not what we want. Two reporters are provided and can be enabled. A complete ```main()``` would be:
 
+### Simple main()
+
+```c++
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+#include <doctest/extensions/doctest_mpi.h>
+```
+
+This is similar to non-mpi dectest usage.
+
+### Customization
 
 ```c++
 #define DOCTEST_CONFIG_IMPLEMENT

--- a/doc/markdown/extensions.md
+++ b/doc/markdown/extensions.md
@@ -71,7 +71,7 @@ mpirun -np 2 unit_test_executable.exe
 #include <doctest/extensions/doctest_mpi.h>
 ```
 
-This is similar to non-mpi dectest usage.
+This is similar to non-mpi doctest usage.
 
 ### Customization
 

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -10,7 +10,7 @@
 #include "mpi_sub_comm.h"
 #include "mpi_reporter.h"
 #include <unordered_map>
-#include <exception>
+
 
 namespace doctest {
 

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_MPI_H
+#define DOCTEST_MPI_H
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 
@@ -164,3 +165,5 @@ insufficient_procs(int test_nb_procs) {
 
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
+
+#endif // DOCTEST_MPI_H

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -1,6 +1,10 @@
 #ifndef DOCTEST_MPI_H
 #define DOCTEST_MPI_H
 
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 
 #include "mpi_sub_comm.h"
@@ -164,5 +168,21 @@ void doctest::execute_mpi_test_case(F func) {
 }
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+int main(int argc, char* argv[]) {
+    doctest::mpi_init_thread(argc,argv,MPI_THREAD_MULTIPLE);
+
+    doctest::Context ctx;
+    ctx.setOption("reporters", "MpiConsoleReporter");
+    ctx.applyCommandLine(argc, argv);
+
+    int test_result = ctx.run();
+
+    doctest::mpi_finalize();
+
+    return test_result;
+}
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
 
 #endif // DOCTEST_MPI_H

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -13,75 +13,77 @@ namespace doctest {
 // we need a sub-communicator of N procs to execute it.
 // It is then registered here and can be re-used
 // by other tests that requires a sub-comm of the same size
-std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
+std::unordered_map<int, mpi_sub_comm> sub_comms_by_size;
 
 // Record if at least one MPI_TEST_CASE was registered "skipped"
 // because there is not enought procs to execute it
 int nb_test_cases_skipped_insufficient_procs = 0;
 
-
 std::string thread_level_to_string(int thread_lvl);
-int mpi_init_thread(int argc, char *argv[], int required_thread_support);
-void mpi_finalize();
-
+int         mpi_init_thread(int argc, char* argv[], int required_thread_support);
+void        mpi_finalize();
 
 // Can be safely called before MPI_Init()
 //   This is needed for MPI_TEST_CASE because we use doctest::skip()
 //   to prevent execution of tests where there is not enough procs,
 //   but doctest::skip() is called during test registration, that is, before main(), and hence before MPI_Init()
 int mpi_comm_world_size() {
-  #if defined(OPEN_MPI)
+#if defined(OPEN_MPI)
     const char* size_str = std::getenv("OMPI_COMM_WORLD_SIZE");
-  #elif defined(I_MPI_VERSION) || defined(MPI_VERSION) // Intel MPI + MPICH (at least)
-    const char* size_str = std::getenv("PMI_SIZE"); // see https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
-  #else
-    #error "Unknown MPI implementation: please submit an issue or a PR to doctest. Meanwhile, you can look at the output of e.g. `mpirun -np 3 env` to search for an environnement variable that contains the size of MPI_COMM_WORLD and extend this code accordingly"
-  #endif
-  if (size_str==nullptr) return 1; // not launched with mpirun/mpiexec, so assume only one process
-  return std::stoi(size_str);
+#elif defined(I_MPI_VERSION) || defined(MPI_VERSION) // Intel MPI + MPICH (at least)
+    const char* size_str = std::getenv(
+            "PMI_SIZE"); // see https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
+#else
+#error "Unknown MPI implementation: please submit an issue or a PR to doctest. Meanwhile, you can look at the output of e.g. `mpirun -np 3 env` to search for an environnement variable that contains the size of MPI_COMM_WORLD and extend this code accordingly"
+#endif
+    if(size_str == nullptr)
+        return 1; // not launched with mpirun/mpiexec, so assume only one process
+    return std::stoi(size_str);
 }
 
 // Record size of MPI_COMM_WORLD with mpi_comm_world_size()
 int world_size_before_init = mpi_comm_world_size();
 
-
 std::string thread_level_to_string(int thread_lvl) {
-  switch (thread_lvl) {
-    case MPI_THREAD_SINGLE:     return "MPI_THREAD_SINGLE";
-    case MPI_THREAD_FUNNELED:   return "MPI_THREAD_FUNNELED";
-    case MPI_THREAD_SERIALIZED: return "MPI_THREAD_SERIALIZED";
-    case MPI_THREAD_MULTIPLE:   return "MPI_THREAD_MULTIPLE";
-    default: return "Invalid MPI thread level";
-  }
+    switch(thread_lvl) {
+        case MPI_THREAD_SINGLE: return "MPI_THREAD_SINGLE";
+        case MPI_THREAD_FUNNELED: return "MPI_THREAD_FUNNELED";
+        case MPI_THREAD_SERIALIZED: return "MPI_THREAD_SERIALIZED";
+        case MPI_THREAD_MULTIPLE: return "MPI_THREAD_MULTIPLE";
+        default: return "Invalid MPI thread level";
+    }
 }
-int mpi_init_thread(int argc, char *argv[], int required_thread_support) {
-  int provided_thread_support;
-  MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
+int mpi_init_thread(int argc, char* argv[], int required_thread_support) {
+    int provided_thread_support;
+    MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
 
-  int world_size;
-  MPI_Comm_size(MPI_COMM_WORLD,&world_size);
-  if (world_size_before_init != world_size) {
-    DOCTEST_INTERNAL_ERROR(
-      "doctest found "+std::to_string(world_size_before_init)+" MPI processes before `MPI_Init_thread`,"
-      " but MPI_COMM_WORLD is actually of size "+std::to_string(world_size)+".\n"
-      "This is most likely due to your MPI implementation not being well supported by doctest. Please report this issue on GitHub"
-    );
-  }
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    if(world_size_before_init != world_size) {
+        DOCTEST_INTERNAL_ERROR("doctest found " + std::to_string(world_size_before_init) +
+                               " MPI processes before `MPI_Init_thread`,"
+                               " but MPI_COMM_WORLD is actually of size " +
+                               std::to_string(world_size) +
+                               ".\n"
+                               "This is most likely due to your MPI implementation not being well "
+                               "supported by doctest. Please report this issue on GitHub");
+    }
 
-  if (provided_thread_support!=required_thread_support) {
-    std::cout <<
-        "WARNING: " + thread_level_to_string(required_thread_support) + " was asked, "
-      + "but only " + thread_level_to_string(provided_thread_support) + " is provided by the MPI library\n";
-  }
-  return provided_thread_support;
+    if(provided_thread_support != required_thread_support) {
+        std::cout << "WARNING: " + thread_level_to_string(required_thread_support) +
+                             " was asked, " + "but only " +
+                             thread_level_to_string(provided_thread_support) +
+                             " is provided by the MPI library\n";
+    }
+    return provided_thread_support;
 }
 void mpi_finalize() {
-  // We need to destroy all created sub-communicators before calling MPI_Finalize()
-  doctest::sub_comms_by_size.clear();
-  MPI_Finalize();
+    // We need to destroy all created sub-communicators before calling MPI_Finalize()
+    doctest::sub_comms_by_size.clear();
+    MPI_Finalize();
 }
 
-} // doctest
+} // namespace doctest
 
 #else // DOCTEST_CONFIG_IMPLEMENT
 
@@ -91,78 +93,89 @@ void mpi_finalize() {
 
 namespace doctest {
 
-extern std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
-extern int nb_test_cases_skipped_insufficient_procs;
-extern int world_size_before_init;
-int mpi_comm_world_size();
+extern std::unordered_map<int, mpi_sub_comm> sub_comms_by_size;
+extern int                                   nb_test_cases_skipped_insufficient_procs;
+extern int                                   world_size_before_init;
+int                                          mpi_comm_world_size();
 
-int mpi_init_thread(int argc, char *argv[], int required_thread_support);
+int  mpi_init_thread(int argc, char* argv[], int required_thread_support);
 void mpi_finalize();
 
-template<int nb_procs, class F>
+template <int nb_procs, class F>
 void execute_mpi_test_case(F func) {
-  auto it = sub_comms_by_size.find(nb_procs);
-  if (it==end(sub_comms_by_size)) {
-    bool was_emplaced = false;
-    std::tie(it,was_emplaced) = sub_comms_by_size.emplace(std::make_pair(nb_procs,mpi_sub_comm(nb_procs)));
-    assert(was_emplaced);
-  }
-  const mpi_sub_comm& sub = it->second;
-  if (sub.comm != MPI_COMM_NULL) {
-    func(sub.rank,nb_procs,sub.comm,std::integral_constant<int,nb_procs>{});
-  };
+    auto it = sub_comms_by_size.find(nb_procs);
+    if(it == end(sub_comms_by_size)) {
+        bool was_emplaced = false;
+        std::tie(it, was_emplaced) =
+                sub_comms_by_size.emplace(std::make_pair(nb_procs, mpi_sub_comm(nb_procs)));
+        assert(was_emplaced);
+    }
+    const mpi_sub_comm& sub = it->second;
+    if(sub.comm != MPI_COMM_NULL) {
+        func(sub.rank, nb_procs, sub.comm, std::integral_constant<int, nb_procs>{});
+    };
 }
 
-inline bool
-insufficient_procs(int test_nb_procs) {
-  static const int world_size = mpi_comm_world_size();
-  bool insufficient = test_nb_procs>world_size;
-  if (insufficient) {
-    ++nb_test_cases_skipped_insufficient_procs;
-  }
-  return insufficient;
+inline bool insufficient_procs(int test_nb_procs) {
+    static const int world_size   = mpi_comm_world_size();
+    bool             insufficient = test_nb_procs > world_size;
+    if(insufficient) {
+        ++nb_test_cases_skipped_insufficient_procs;
+    }
+    return insufficient;
 }
 
-} // doctest
+} // namespace doctest
 
+#define DOCTEST_MPI_GEN_ASSERTION(rank_to_test, assertion, ...)                                    \
+    static_assert(rank_to_test < test_nb_procs_as_int_constant.value,                              \
+                  "Trying to assert on a rank greater than the number of procs of the test!");     \
+    if(rank_to_test == test_rank)                                                                  \
+    assertion(__VA_ARGS__)
 
-#define DOCTEST_MPI_GEN_ASSERTION(rank_to_test, assertion, ...) \
-  static_assert(rank_to_test<test_nb_procs_as_int_constant.value,"Trying to assert on a rank greater than the number of procs of the test!"); \
-  if(rank_to_test == test_rank) assertion(__VA_ARGS__)
+#define DOCTEST_MPI_WARN(rank_to_test, ...)                                                        \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_WARN, __VA_ARGS__)
+#define DOCTEST_MPI_CHECK(rank_to_test, ...)                                                       \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_CHECK, __VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE(rank_to_test, ...)                                                     \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_REQUIRE, __VA_ARGS__)
+#define DOCTEST_MPI_WARN_FALSE(rank_to_test, ...)                                                  \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_WARN_FALSE, __VA_ARGS__)
+#define DOCTEST_MPI_CHECK_FALSE(rank_to_test, ...)                                                 \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_CHECK_FALSE, __VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE_FALSE(rank_to_test, ...)                                               \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_REQUIRE_FALSE, __VA_ARGS__)
 
-#define DOCTEST_MPI_WARN(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN,__VA_ARGS__)
-#define DOCTEST_MPI_CHECK(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK,__VA_ARGS__)
-#define DOCTEST_MPI_REQUIRE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE,__VA_ARGS__)
-#define DOCTEST_MPI_WARN_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN_FALSE,__VA_ARGS__)
-#define DOCTEST_MPI_CHECK_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK_FALSE,__VA_ARGS__)
-#define DOCTEST_MPI_REQUIRE_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE_FALSE,__VA_ARGS__)
+#define DOCTEST_CREATE_MPI_TEST_CASE(name, nb_procs, func)                                         \
+    static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs,               \
+                     DOCTEST_UNUSED MPI_Comm test_comm,                                            \
+                     DOCTEST_UNUSED          std::integral_constant<int, nb_procs>);                        \
+    TEST_CASE(name* doctest::description("MPI_TEST_CASE") *                                        \
+              doctest::skip(doctest::insufficient_procs(nb_procs))) {                              \
+        doctest::execute_mpi_test_case<nb_procs>(func);                                            \
+    }                                                                                              \
+    static void func(                                                                              \
+            DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs,                        \
+            DOCTEST_UNUSED MPI_Comm test_comm,                                                     \
+            DOCTEST_UNUSED std::integral_constant<int, nb_procs> test_nb_procs_as_int_constant)
+// DOC: test_rank, test_nb_procs, and test_comm are available UNDER THESE SPECIFIC NAMES in the body of the unit test
+// DOC: test_nb_procs_as_int_constant is equal to test_nb_procs, but as a compile time value
+//          (used in CHECK-like macros to assert the checked rank exists)
 
-#define DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,func) \
-  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs>); \
-  TEST_CASE(name * doctest::description("MPI_TEST_CASE") * doctest::skip(doctest::insufficient_procs(nb_procs))) { \
-    doctest::execute_mpi_test_case<nb_procs>(func); \
-  } \
-  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs> test_nb_procs_as_int_constant)
-  // DOC: test_rank, test_nb_procs, and test_comm are available UNDER THESE SPECIFIC NAMES in the body of the unit test
-  // DOC: test_nb_procs_as_int_constant is equal to test_nb_procs, but as a compile time value
-  //          (used in CHECK-like macros to assert the checked rank exists)
-
-#define DOCTEST_MPI_TEST_CASE(name,nb_procs) \
-  DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,DOCTEST_ANONYMOUS(DOCTEST_MPI_FUNC))
-
+#define DOCTEST_MPI_TEST_CASE(name, nb_procs)                                                      \
+    DOCTEST_CREATE_MPI_TEST_CASE(name, nb_procs, DOCTEST_ANONYMOUS(DOCTEST_MPI_FUNC))
 
 // == SHORT VERSIONS OF THE MACROS
 #if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
-#define MPI_WARN           DOCTEST_MPI_WARN
-#define MPI_CHECK          DOCTEST_MPI_CHECK
-#define MPI_REQUIRE        DOCTEST_MPI_REQUIRE
-#define MPI_WARN_FALSE     DOCTEST_MPI_WARN_FALSE
-#define MPI_CHECK_FALSE    DOCTEST_MPI_CHECK_FALSE
-#define MPI_REQUIRE_FALSE  DOCTEST_MPI_REQUIRE_FALSE
+#define MPI_WARN DOCTEST_MPI_WARN
+#define MPI_CHECK DOCTEST_MPI_CHECK
+#define MPI_REQUIRE DOCTEST_MPI_REQUIRE
+#define MPI_WARN_FALSE DOCTEST_MPI_WARN_FALSE
+#define MPI_CHECK_FALSE DOCTEST_MPI_CHECK_FALSE
+#define MPI_REQUIRE_FALSE DOCTEST_MPI_REQUIRE_FALSE
 
-#define MPI_TEST_CASE      DOCTEST_MPI_TEST_CASE
+#define MPI_TEST_CASE DOCTEST_MPI_TEST_CASE
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
-
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
 

--- a/doctest/extensions/doctest_util.h
+++ b/doctest/extensions/doctest_util.h
@@ -11,7 +11,8 @@
 // https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
 //
 
-#pragma once
+#ifndef DOCTEST_UTIL_H
+#define DOCTEST_UTIL_H
 
 #ifndef DOCTEST_LIBRARY_INCLUDED
 #include "../doctest.h"
@@ -32,3 +33,5 @@ namespace doctest {
     }
 
 } // namespace doctest
+
+#endif // DOCTEST_UTIL_H

--- a/doctest/extensions/doctest_util.h
+++ b/doctest/extensions/doctest_util.h
@@ -24,13 +24,13 @@
 
 namespace doctest {
 
-    inline void applyCommandLine(doctest::Context& ctx, const std::vector<std::string>& args) {
-        auto doctest_args = std::make_unique<const char*[]>(args.size());
-        for (size_t i = 0; i < args.size(); ++i) {
-            doctest_args[i] = args[i].c_str();
-        }
-        ctx.applyCommandLine(args.size(), doctest_args.get());
+inline void applyCommandLine(doctest::Context& ctx, const std::vector<std::string>& args) {
+    auto doctest_args = std::make_unique<const char*[]>(args.size());
+    for(size_t i = 0; i < args.size(); ++i) {
+        doctest_args[i] = args[i].c_str();
     }
+    ctx.applyCommandLine(args.size(), doctest_args.get());
+}
 
 } // namespace doctest
 

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,8 +1,8 @@
 #ifndef DOCTEST_REPORTER_H
 #define DOCTEST_REPORTER_H
 
-// #include <doctest/doctest.h>
 #include <fstream>
+#include <streambuf>
 #include <string>
 #include "mpi.h"
 
@@ -12,7 +12,12 @@
 namespace doctest {
 
 extern int nb_test_cases_skipped_insufficient_procs;
-int        mpi_comm_world_size();
+
+// Can be safely called before MPI_Init()
+//   This is needed for MPI_TEST_CASE because we use doctest::skip()
+//   to prevent execution of tests where there is not enough procs,
+//   but doctest::skip() is called during test registration, that is, before main(), and hence before MPI_Init()
+int mpi_comm_world_size();
 
 namespace {
 

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_REPORTER_H
+#define DOCTEST_REPORTER_H
 
 // #include <doctest/doctest.h>
 #include <fstream>
@@ -266,3 +267,5 @@ REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
 
 } // anonymous
 } // doctest
+
+#endif // DOCTEST_REPORTER_H

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -6,266 +6,272 @@
 #include <string>
 #include "mpi.h"
 
-
 #include <vector>
 #include <mutex>
 
 namespace doctest {
 
 extern int nb_test_cases_skipped_insufficient_procs;
-int mpi_comm_world_size();
+int        mpi_comm_world_size();
 
 namespace {
 
-// https://stackoverflow.com/a/11826666/1583122
-struct NullBuffer : std::streambuf {
-  int overflow(int c) { return c; }
-};
-class NullStream : public std::ostream {
-  public:
-    NullStream()
-      : std::ostream(&nullBuff)
-    {}
-  private:
-    NullBuffer nullBuff = {};
-};
-static NullStream nullStream;
+    // https://stackoverflow.com/a/11826666/1583122
+    struct NullBuffer : std::streambuf
+    {
+        int overflow(int c) { return c; }
+    };
+    class NullStream : public std::ostream
+    {
+    public:
+        NullStream()
+                : std::ostream(&nullBuff) {}
 
+    private:
+        NullBuffer nullBuff = {};
+    };
+    static NullStream nullStream;
 
-/* \brief Extends the ConsoleReporter of doctest
+    /* \brief Extends the ConsoleReporter of doctest
  *        Each process writes its results to its own file
  *        Intended to be used when a test assertion fails and the user wants to know exactly what happens on which process
  */
-struct MpiFileReporter : public ConsoleReporter {
-  std::ofstream logfile_stream = {};
+    struct MpiFileReporter : public ConsoleReporter
+    {
+        std::ofstream logfile_stream = {};
 
-  MpiFileReporter(const ContextOptions& co)
-    : ConsoleReporter(co,logfile_stream)
-  {
-    int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MpiFileReporter(const ContextOptions& co)
+                : ConsoleReporter(co, logfile_stream) {
+            int rank = 0;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    std::string logfile_name = "doctest_" + std::to_string(rank) + ".log";
+            std::string logfile_name = "doctest_" + std::to_string(rank) + ".log";
 
-    logfile_stream = std::ofstream(logfile_name.c_str(), std::fstream::out);
-  }
-};
+            logfile_stream = std::ofstream(logfile_name.c_str(), std::fstream::out);
+        }
+    };
 
-
-/* \brief Extends the ConsoleReporter of doctest
+    /* \brief Extends the ConsoleReporter of doctest
  *        Allows to manage the execution of tests in a parallel framework
  *        All results are collected on rank 0
  */
-struct MpiConsoleReporter : public ConsoleReporter {
-private:
-  static std::ostream& replace_by_null_if_not_rank_0(std::ostream* os) {
-    int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank==0) {
-      return *os;
-    } else {
-      return nullStream;
-    }
-  }
-  std::vector<std::pair<std::string, int>> m_failure_str_queue = {};
-public:
-  MpiConsoleReporter(const ContextOptions& co)
-    : ConsoleReporter(co,replace_by_null_if_not_rank_0(co.cout))
-  {}
-
-  std::string file_line_to_string(const char* file, int line,
-                                  const char* tail = ""){
-    std::stringstream ss;
-    ss << skipPathFromFilename(file)
-    << (opt.gnu_file_line ? ":" : "(")
-    << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-    << (opt.gnu_file_line ? ":" : "):") << tail;
-    return ss.str();
-  }
-
-  void test_run_end(const TestRunStats& p) override {
-    ConsoleReporter::test_run_end(p);
-
-    const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-
-    // -----------------------------------------------------
-    // > Gather information in rank 0
-    int n_rank, rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &n_rank);
-
-    int g_numAsserts         = 0;
-    int g_numAssertsFailed   = 0;
-    int g_numTestCasesFailed = 0;
-
-    MPI_Reduce(&p.numAsserts        , &g_numAsserts        , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Reduce(&p.numAssertsFailed  , &g_numAssertsFailed  , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Reduce(&p.numTestCasesFailed, &g_numTestCasesFailed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-
-    std::vector<int> numAssertsFailedByRank;
-    if(rank == 0){
-      numAssertsFailedByRank.resize(static_cast<std::size_t>(n_rank));
-    }
-
-    MPI_Gather(&p.numAssertsFailed, 1, MPI_INT, numAssertsFailedByRank.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-    if(rank == 0) {
-      separator_to_stream();
-      s << Color::Cyan << "[doctest] " << Color::None << "assertions on all processes: " << std::setw(6)
-        << g_numAsserts << " | "
-        << ((g_numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-        << std::setw(6) << (g_numAsserts - g_numAssertsFailed) << " passed" << Color::None
-        << " | " << (g_numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
-        << g_numAssertsFailed << " failed" << Color::None << " |\n";
-      if (nb_test_cases_skipped_insufficient_procs>0) {
-        s << Color::Cyan << "[doctest] " << Color::Yellow << "WARNING: Skipped ";
-        if (nb_test_cases_skipped_insufficient_procs>1) {
-          s << nb_test_cases_skipped_insufficient_procs << " tests requiring more than ";
-        } else {
-          s << nb_test_cases_skipped_insufficient_procs << " test requiring more than ";
+    struct MpiConsoleReporter : public ConsoleReporter
+    {
+    private:
+        static std::ostream& replace_by_null_if_not_rank_0(std::ostream* os) {
+            int rank = 0;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            if(rank == 0) {
+                return *os;
+            } else {
+                return nullStream;
+            }
         }
-        if (mpi_comm_world_size()>1) {
-          s << mpi_comm_world_size() << " MPI processes to run\n";
-        } else {
-          s << mpi_comm_world_size() << " MPI process to run\n";
-        }
-      }
+        std::vector<std::pair<std::string, int>> m_failure_str_queue = {};
 
-      separator_to_stream();
-      if(g_numAssertsFailed > 0){
+    public:
+        MpiConsoleReporter(const ContextOptions& co)
+                : ConsoleReporter(co, replace_by_null_if_not_rank_0(co.cout)) {}
 
-        s << Color::Cyan << "[doctest] " << Color::None << "fail on rank:" << std::setw(6) << "\n";
-        for(std::size_t i = 0; i < numAssertsFailedByRank.size(); ++i){
-          if( numAssertsFailedByRank[i] > 0 ){
-            s << std::setw(16) << " -> On rank [" << i << "] with " << numAssertsFailedByRank[i] << " test failed" << std::endl;
-          }
-        }
-      }
-      s << Color::Cyan << "[doctest] " << Color::None
-        << "Status: " << (g_numTestCasesFailed > 0 ? Color::Red : Color::Green)
-        << ((g_numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
-    }
-  }
-
-  void test_case_end(const CurrentTestCaseStats& st) override {
-    if (is_mpi_test_case()) {
-      // function called by every rank at the end of a test
-      // if failed assertions happened, they have been sent to rank 0
-      // here rank zero gathers them and prints them all
-
-      int rank;
-      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-      std::vector<MPI_Request> requests;
-      requests.reserve(m_failure_str_queue.size());  // avoid realloc & copy of MPI_Request
-      for (const std::pair<std::string, int> &failure : m_failure_str_queue)
-      {
-        const std::string & failure_str = failure.first;
-        const int failure_line = failure.second;
-
-        int failure_msg_size = static_cast<int>(failure_str.size());
-
-        requests.push_back(MPI_REQUEST_NULL);
-        MPI_Isend(failure_str.c_str(), failure_msg_size, MPI_BYTE,
-                 0, failure_line, MPI_COMM_WORLD, &requests.back()); // Tag = file line
-      }
-
-
-      // Compute the number of assert with fail among all procs
-      const int nb_fail_asserts = static_cast<int>(m_failure_str_queue.size());
-      int nb_fail_asserts_glob = 0;
-      MPI_Reduce(&nb_fail_asserts, &nb_fail_asserts_glob, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-
-      if(rank == 0) {
-        MPI_Status status;
-        MPI_Status status_recv;
-
-        using id_string = std::pair<int,std::string>;
-        std::vector<id_string> msgs(static_cast<std::size_t>(nb_fail_asserts_glob));
-
-        for (std::size_t i=0; i<static_cast<std::size_t>(nb_fail_asserts_glob); ++i) {
-          MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
-
-          int count;
-          MPI_Get_count(&status, MPI_BYTE, &count);
-
-          std::string recv_msg(static_cast<std::size_t>(count),'\0');
-          void* recv_msg_data = const_cast<char*>(recv_msg.data()); // const_cast needed. Non-const .data() exists in C++11 though...
-          MPI_Recv(recv_msg_data, count, MPI_BYTE, status.MPI_SOURCE,
-                   status.MPI_TAG, MPI_COMM_WORLD, &status_recv);
-
-          msgs[i] = {status.MPI_SOURCE,recv_msg};
+        std::string file_line_to_string(const char* file, int line, const char* tail = "") {
+            std::stringstream ss;
+            ss << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+               << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+               << (opt.gnu_file_line ? ":" : "):") << tail;
+            return ss.str();
         }
 
-        std::sort(begin(msgs),end(msgs),[](const id_string& x, const id_string& y){ return x.first < y.first; });
+        void test_run_end(const TestRunStats& p) override {
+            ConsoleReporter::test_run_end(p);
 
-        // print
-        if (nb_fail_asserts_glob>0) {
-          separator_to_stream();
-          file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
-          if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
-            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-          if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-            s << Color::Yellow << "TEST CASE:  ";
-          s << Color::None << tc->m_name << "\n\n";
-          for(const auto& msg : msgs) {
-            s << msg.second;
-          }
-          s << "\n";
+            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+
+            // -----------------------------------------------------
+            // > Gather information in rank 0
+            int n_rank, rank;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            MPI_Comm_size(MPI_COMM_WORLD, &n_rank);
+
+            int g_numAsserts         = 0;
+            int g_numAssertsFailed   = 0;
+            int g_numTestCasesFailed = 0;
+
+            MPI_Reduce(&p.numAsserts, &g_numAsserts, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&p.numAssertsFailed, &g_numAssertsFailed, 1, MPI_INT, MPI_SUM, 0,
+                       MPI_COMM_WORLD);
+            MPI_Reduce(&p.numTestCasesFailed, &g_numTestCasesFailed, 1, MPI_INT, MPI_SUM, 0,
+                       MPI_COMM_WORLD);
+
+            std::vector<int> numAssertsFailedByRank;
+            if(rank == 0) {
+                numAssertsFailedByRank.resize(static_cast<std::size_t>(n_rank));
+            }
+
+            MPI_Gather(&p.numAssertsFailed, 1, MPI_INT, numAssertsFailedByRank.data(), 1, MPI_INT,
+                       0, MPI_COMM_WORLD);
+
+            if(rank == 0) {
+                separator_to_stream();
+                s << Color::Cyan << "[doctest] " << Color::None
+                  << "assertions on all processes: " << std::setw(6) << g_numAsserts << " | "
+                  << ((g_numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+                  << std::setw(6) << (g_numAsserts - g_numAssertsFailed) << " passed" << Color::None
+                  << " | " << (g_numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
+                  << g_numAssertsFailed << " failed" << Color::None << " |\n";
+                if(nb_test_cases_skipped_insufficient_procs > 0) {
+                    s << Color::Cyan << "[doctest] " << Color::Yellow << "WARNING: Skipped ";
+                    if(nb_test_cases_skipped_insufficient_procs > 1) {
+                        s << nb_test_cases_skipped_insufficient_procs
+                          << " tests requiring more than ";
+                    } else {
+                        s << nb_test_cases_skipped_insufficient_procs
+                          << " test requiring more than ";
+                    }
+                    if(mpi_comm_world_size() > 1) {
+                        s << mpi_comm_world_size() << " MPI processes to run\n";
+                    } else {
+                        s << mpi_comm_world_size() << " MPI process to run\n";
+                    }
+                }
+
+                separator_to_stream();
+                if(g_numAssertsFailed > 0) {
+                    s << Color::Cyan << "[doctest] " << Color::None
+                      << "fail on rank:" << std::setw(6) << "\n";
+                    for(std::size_t i = 0; i < numAssertsFailedByRank.size(); ++i) {
+                        if(numAssertsFailedByRank[i] > 0) {
+                            s << std::setw(16) << " -> On rank [" << i << "] with "
+                              << numAssertsFailedByRank[i] << " test failed" << std::endl;
+                        }
+                    }
+                }
+                s << Color::Cyan << "[doctest] " << Color::None
+                  << "Status: " << (g_numTestCasesFailed > 0 ? Color::Red : Color::Green)
+                  << ((g_numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None
+                  << std::endl;
+            }
         }
-      }
 
-      MPI_Waitall(static_cast<int>(requests.size()), requests.data(), MPI_STATUSES_IGNORE);
-      m_failure_str_queue.clear();
-    }
+        void test_case_end(const CurrentTestCaseStats& st) override {
+            if(is_mpi_test_case()) {
+                // function called by every rank at the end of a test
+                // if failed assertions happened, they have been sent to rank 0
+                // here rank zero gathers them and prints them all
 
-    ConsoleReporter::test_case_end(st);
-  }
+                int rank;
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  bool is_mpi_test_case() const {
-    return tc->m_description != nullptr
-        && std::string(tc->m_description) == std::string("MPI_TEST_CASE");
-  }
+                std::vector<MPI_Request> requests;
+                requests.reserve(m_failure_str_queue.size()); // avoid realloc & copy of MPI_Request
+                for(const std::pair<std::string, int>& failure : m_failure_str_queue) {
+                    const std::string& failure_str  = failure.first;
+                    const int          failure_line = failure.second;
 
-  void log_assert(const AssertData& rb) override {
-    if (!is_mpi_test_case()) {
-      ConsoleReporter::log_assert(rb);
-    } else {
-      int rank;
-      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                    int failure_msg_size = static_cast<int>(failure_str.size());
 
+                    requests.push_back(MPI_REQUEST_NULL);
+                    MPI_Isend(failure_str.c_str(), failure_msg_size, MPI_BYTE, 0, failure_line,
+                              MPI_COMM_WORLD, &requests.back()); // Tag = file line
+                }
 
-      if(!rb.m_failed && !opt.success)
-        return;
+                // Compute the number of assert with fail among all procs
+                const int nb_fail_asserts      = static_cast<int>(m_failure_str_queue.size());
+                int       nb_fail_asserts_glob = 0;
+                MPI_Reduce(&nb_fail_asserts, &nb_fail_asserts_glob, 1, MPI_INT, MPI_SUM, 0,
+                           MPI_COMM_WORLD);
 
-      std::lock_guard<std::mutex> lock(mutex);
+                if(rank == 0) {
+                    MPI_Status status;
+                    MPI_Status status_recv;
 
-      std::stringstream failure_msg;
-      failure_msg << Color::Red << "On rank [" << rank << "] : " << Color::None;
-      failure_msg << file_line_to_string(rb.m_file, rb.m_line, " ");
+                    using id_string = std::pair<int, std::string>;
+                    std::vector<id_string> msgs(static_cast<std::size_t>(nb_fail_asserts_glob));
 
-      if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==0){
-        failure_msg << Color::Cyan
-                    << assertString(rb.m_at)
-                    << "( " << rb.m_expr << " ) "
-                    << Color::None
+                    for(std::size_t i = 0; i < static_cast<std::size_t>(nb_fail_asserts_glob);
+                        ++i) {
+                        MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-                    << (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n")
-                    << "  values: "
-                    << assertString(rb.m_at)
-                    << "( " << rb.m_decomp.c_str() << " )\n";
-      }
+                        int count;
+                        MPI_Get_count(&status, MPI_BYTE, &count);
 
-      m_failure_str_queue.push_back({failure_msg.str(), rb.m_line});
-    }
-  }
-}; // MpiConsoleReporter
+                        std::string recv_msg(static_cast<std::size_t>(count), '\0');
+                        void*       recv_msg_data = const_cast<char*>(
+                                recv_msg.data()); // const_cast needed. Non-const .data() exists in C++11 though...
+                        MPI_Recv(recv_msg_data, count, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
+                                 MPI_COMM_WORLD, &status_recv);
 
-// "1" is the priority - used for ordering when multiple reporters/listeners are used
-REGISTER_REPORTER("MpiConsoleReporter", 1, MpiConsoleReporter);
-REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
+                        msgs[i] = {status.MPI_SOURCE, recv_msg};
+                    }
 
-} // anonymous
-} // doctest
+                    std::sort(begin(msgs), end(msgs), [](const id_string& x, const id_string& y) {
+                        return x.first < y.first;
+                    });
+
+                    // print
+                    if(nb_fail_asserts_glob > 0) {
+                        separator_to_stream();
+                        file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
+                        if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+                            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite
+                              << "\n";
+                        if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+                            s << Color::Yellow << "TEST CASE:  ";
+                        s << Color::None << tc->m_name << "\n\n";
+                        for(const auto& msg : msgs) {
+                            s << msg.second;
+                        }
+                        s << "\n";
+                    }
+                }
+
+                MPI_Waitall(static_cast<int>(requests.size()), requests.data(),
+                            MPI_STATUSES_IGNORE);
+                m_failure_str_queue.clear();
+            }
+
+            ConsoleReporter::test_case_end(st);
+        }
+
+        bool is_mpi_test_case() const {
+            return tc->m_description != nullptr &&
+                   std::string(tc->m_description) == std::string("MPI_TEST_CASE");
+        }
+
+        void log_assert(const AssertData& rb) override {
+            if(!is_mpi_test_case()) {
+                ConsoleReporter::log_assert(rb);
+            } else {
+                int rank;
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+                if(!rb.m_failed && !opt.success)
+                    return;
+
+                std::lock_guard<std::mutex> lock(mutex);
+
+                std::stringstream failure_msg;
+                failure_msg << Color::Red << "On rank [" << rank << "] : " << Color::None;
+                failure_msg << file_line_to_string(rb.m_file, rb.m_line, " ");
+
+                if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) == 0) {
+                    failure_msg << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr
+                                << " ) " << Color::None
+
+                                << (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n")
+                                << "  values: " << assertString(rb.m_at) << "( "
+                                << rb.m_decomp.c_str() << " )\n";
+                }
+
+                m_failure_str_queue.push_back({failure_msg.str(), rb.m_line});
+            }
+        }
+    }; // MpiConsoleReporter
+
+    // "1" is the priority - used for ordering when multiple reporters/listeners are used
+    REGISTER_REPORTER("MpiConsoleReporter", 1, MpiConsoleReporter);
+    REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
+
+} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_REPORTER_H

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,5 +1,5 @@
-#ifndef DOCTEST_REPORTER_H
-#define DOCTEST_REPORTER_H
+#ifndef DOCTEST_MPI_REPORTER_H
+#define DOCTEST_MPI_REPORTER_H
 
 #include <fstream>
 #include <streambuf>

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -8,77 +8,72 @@
 
 namespace doctest {
 
-inline
-int mpi_world_nb_procs() {
-  int n;
-  MPI_Comm_size(MPI_COMM_WORLD, &n);
-  return n;
+inline int mpi_world_nb_procs() {
+    int n;
+    MPI_Comm_size(MPI_COMM_WORLD, &n);
+    return n;
 }
 
-struct mpi_sub_comm {
-  int nb_procs;
-  int rank;
-  MPI_Comm comm;
+struct mpi_sub_comm
+{
+    int      nb_procs;
+    int      rank;
+    MPI_Comm comm;
 
-  mpi_sub_comm( mpi_sub_comm const& ) = delete;
-  mpi_sub_comm& operator=( mpi_sub_comm const& ) = delete;
+    mpi_sub_comm(mpi_sub_comm const&)            = delete;
+    mpi_sub_comm& operator=(mpi_sub_comm const&) = delete;
 
-  mpi_sub_comm(int nb_prcs) noexcept
-    : nb_procs(nb_prcs)
-    , rank(-1)
-    , comm(MPI_COMM_NULL)
-  {
-    int comm_world_rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
-    if (nb_procs>mpi_world_nb_procs()) {
-      if (comm_world_rank==0) {
-        MESSAGE(
-          "Unable to run test: need ", std::to_string(nb_procs), " procs",
-          " but program launched with only ", std::to_string(doctest::mpi_world_nb_procs()), "."
-        );
-        CHECK(nb_procs<=mpi_world_nb_procs());
-      }
-    } else {
-      int color = MPI_UNDEFINED;
-      if(comm_world_rank < nb_procs){
-        color = 0;
-      }
-      MPI_Comm_split(MPI_COMM_WORLD, color, comm_world_rank, &comm);
+    mpi_sub_comm(int nb_prcs) noexcept
+            : nb_procs(nb_prcs)
+            , rank(-1)
+            , comm(MPI_COMM_NULL) {
+        int comm_world_rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
+        if(nb_procs > mpi_world_nb_procs()) {
+            if(comm_world_rank == 0) {
+                MESSAGE("Unable to run test: need ", std::to_string(nb_procs), " procs",
+                        " but program launched with only ",
+                        std::to_string(doctest::mpi_world_nb_procs()), ".");
+                CHECK(nb_procs <= mpi_world_nb_procs());
+            }
+        } else {
+            int color = MPI_UNDEFINED;
+            if(comm_world_rank < nb_procs) {
+                color = 0;
+            }
+            MPI_Comm_split(MPI_COMM_WORLD, color, comm_world_rank, &comm);
 
-      if(comm != MPI_COMM_NULL){
-        MPI_Comm_rank(comm, &rank);
-        assert(rank==comm_world_rank);
-      }
+            if(comm != MPI_COMM_NULL) {
+                MPI_Comm_rank(comm, &rank);
+                assert(rank == comm_world_rank);
+            }
+        }
     }
-  }
 
-  void destroy_comm() {
-    if(comm != MPI_COMM_NULL){
-      MPI_Comm_free(&comm);
+    void destroy_comm() {
+        if(comm != MPI_COMM_NULL) {
+            MPI_Comm_free(&comm);
+        }
     }
-  }
-  
-  mpi_sub_comm(mpi_sub_comm&& x)
-    : nb_procs(x.nb_procs)
-    , rank(x.rank)
-    , comm(x.comm)
-  {
-    x.comm = MPI_COMM_NULL;
-  }
-  mpi_sub_comm& operator=(mpi_sub_comm&& x) {
-    destroy_comm();
-    nb_procs = x.nb_procs;
-    rank = x.rank;
-    comm = x.comm;
-    x.comm = MPI_COMM_NULL;
-    return *this;
-  }
 
-  ~mpi_sub_comm() {
-    destroy_comm();
-  }
+    mpi_sub_comm(mpi_sub_comm&& x)
+            : nb_procs(x.nb_procs)
+            , rank(x.rank)
+            , comm(x.comm) {
+        x.comm = MPI_COMM_NULL;
+    }
+    mpi_sub_comm& operator=(mpi_sub_comm&& x) {
+        destroy_comm();
+        nb_procs = x.nb_procs;
+        rank     = x.rank;
+        comm     = x.comm;
+        x.comm   = MPI_COMM_NULL;
+        return *this;
+    }
+
+    ~mpi_sub_comm() { destroy_comm(); }
 };
 
-} // doctest
+} // namespace doctest
 
 #endif // DOCTEST_SUB_COMM_H

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -1,5 +1,5 @@
-#ifndef DOCTEST_SUB_COMM_H
-#define DOCTEST_SUB_COMM_H
+#ifndef DOCTEST_MPI_SUB_COMM_H
+#define DOCTEST_MPI_SUB_COMM_H
 
 #include "mpi.h"
 #include "doctest/doctest.h"

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_SUB_COMM_H
+#define DOCTEST_SUB_COMM_H
 
 #include "mpi.h"
 #include "doctest/doctest.h"
@@ -79,3 +80,5 @@ struct mpi_sub_comm {
 };
 
 } // doctest
+
+#endif // DOCTEST_SUB_COMM_H

--- a/examples/mpi/CMakeLists.txt
+++ b/examples/mpi/CMakeLists.txt
@@ -1,7 +1,10 @@
 find_package(MPI COMPONENTS CXX)
 if(MPI_FOUND)
-    add_executable(test_mpi main.cpp mpi.cpp)
+    add_executable(test_mpi main.cpp)
     target_link_libraries(test_mpi doctest ${CMAKE_THREAD_LIBS_INIT} MPI::MPI_CXX)
+    add_executable(test_mpi_with_main mpi.cpp)
+    target_link_libraries(test_mpi_with_main doctest ${CMAKE_THREAD_LIBS_INIT} MPI::MPI_CXX)
 
-    doctest_add_test(NO_OUTPUT NAME test_mpi COMMAND mpirun -np 3 $<TARGET_FILE:test_mpi>)
+    doctest_add_test(NO_OUTPUT NAME test_mpi           COMMAND mpirun -np 3 $<TARGET_FILE:test_mpi>)
+    doctest_add_test(NO_OUTPUT NAME test_mpi_with_main COMMAND mpirun -np 3 $<TARGET_FILE:test_mpi_with_main>)
 endif()

--- a/examples/mpi/main.cpp
+++ b/examples/mpi/main.cpp
@@ -1,6 +1,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 
 #include <doctest/extensions/doctest_mpi.h>
+#include "mpi.cpp"
 
 int main(int argc, char** argv) {
   doctest::mpi_init_thread(argc,argv,MPI_THREAD_MULTIPLE);

--- a/examples/mpi/mpi.cpp
+++ b/examples/mpi/mpi.cpp
@@ -1,3 +1,5 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+
 #include <doctest/extensions/doctest_mpi.h>
 
 int f_for_test(int rank);


### PR DESCRIPTION
Dear, sir

- Fixed linker error by restructuring the code when tried to use cmake to integrate doctest with mpi.
- Standardising the style of the code using project `.clang-format`.
- Used 'Include Guards' instead of `#program once` to improve compatibility.
- Added macro `DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN` to provide a default main entry for mpi tests.
- Markdown documentation has also been updated.

Thanks for open sourcing this useful library.