### PR TITLE
Added macro to provide a default main entry for mpi tests.

### DIFF
--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -1,6 +1,12 @@
 #ifndef DOCTEST_MPI_H
 #define DOCTEST_MPI_H
 
+
+#if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
+#define DOCTEST_CONFIG_IMPLEMENT
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+
+
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 
 #include <unordered_map>
@@ -162,5 +168,23 @@ insufficient_procs(int test_nb_procs) {
 
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
+
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+int main(int argc, char* argv[]) {
+    doctest::mpi_init_thread(argc,argv,MPI_THREAD_MULTIPLE);
+
+    doctest::Context ctx;
+    ctx.setOption("reporters", "MpiConsoleReporter");
+    ctx.applyCommandLine(argc, argv);
+
+    int test_result = ctx.run();
+
+    doctest::mpi_finalize();
+
+    return test_result;
+}
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN
+
 
 #endif // DOCTEST_MPI_H

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_MPI_H
+#define DOCTEST_MPI_H
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 
@@ -164,3 +165,5 @@ insufficient_procs(int test_nb_procs) {
 
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
+
+#endif // DOCTEST_MPI_H

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -3,9 +3,10 @@
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 
-#include "doctest/extensions/mpi_sub_comm.h"
-#include "mpi_reporter.h"
 #include <unordered_map>
+#include "doctest/doctest.h"
+#include "mpi_sub_comm.h"
+#include "mpi_reporter.h"
 
 namespace doctest {
 
@@ -25,10 +26,19 @@ int mpi_init_thread(int argc, char *argv[], int required_thread_support);
 void mpi_finalize();
 
 
+template<int nb_procs, class F>
+void execute_mpi_test_case(F func);
+
+
+inline bool
+insufficient_procs(int test_nb_procs);
+
+
 // Can be safely called before MPI_Init()
 //   This is needed for MPI_TEST_CASE because we use doctest::skip()
 //   to prevent execution of tests where there is not enough procs,
-//   but doctest::skip() is called during test registration, that is, before main(), and hence before MPI_Init()
+//   but doctest::skip() is called during test registration, that is, before main(),
+//   and hence before MPI_Init()
 int mpi_comm_world_size() {
   #if defined(OPEN_MPI)
     const char* size_str = std::getenv("OMPI_COMM_WORLD_SIZE");
@@ -54,6 +64,8 @@ std::string thread_level_to_string(int thread_lvl) {
     default: return "Invalid MPI thread level";
   }
 }
+
+
 int mpi_init_thread(int argc, char *argv[], int required_thread_support) {
   int provided_thread_support;
   MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
@@ -75,29 +87,14 @@ int mpi_init_thread(int argc, char *argv[], int required_thread_support) {
   }
   return provided_thread_support;
 }
+
+
 void mpi_finalize() {
   // We need to destroy all created sub-communicators before calling MPI_Finalize()
   doctest::sub_comms_by_size.clear();
   MPI_Finalize();
 }
 
-} // doctest
-
-#else // DOCTEST_CONFIG_IMPLEMENT
-
-#include "doctest/extensions/mpi_sub_comm.h"
-#include <unordered_map>
-#include <exception>
-
-namespace doctest {
-
-extern std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
-extern int nb_test_cases_skipped_insufficient_procs;
-extern int world_size_before_init;
-int mpi_comm_world_size();
-
-int mpi_init_thread(int argc, char *argv[], int required_thread_support);
-void mpi_finalize();
 
 template<int nb_procs, class F>
 void execute_mpi_test_case(F func) {

--- a/doctest/extensions/doctest_util.h
+++ b/doctest/extensions/doctest_util.h
@@ -11,7 +11,8 @@
 // https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
 //
 
-#pragma once
+#ifndef DOCTEST_UTIL_H
+#define DOCTEST_UTIL_H
 
 #ifndef DOCTEST_LIBRARY_INCLUDED
 #include "../doctest.h"
@@ -32,3 +33,5 @@ namespace doctest {
     }
 
 } // namespace doctest
+
+#endif // DOCTEST_UTIL_H

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,5 +1,5 @@
-#ifndef DOCTEST_REPORTER_H
-#define DOCTEST_REPORTER_H
+#ifndef DOCTEST_MPI_REPORTER_H
+#define DOCTEST_MPI_REPORTER_H
 
 // #include <doctest/doctest.h>
 #include <fstream>

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_REPORTER_H
+#define DOCTEST_REPORTER_H
 
 // #include <doctest/doctest.h>
 #include <fstream>
@@ -266,3 +267,5 @@ REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
 
 } // anonymous
 } // doctest
+
+#endif // DOCTEST_REPORTER_H

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -1,10 +1,10 @@
 #ifndef DOCTEST_MPI_REPORTER_H
 #define DOCTEST_MPI_REPORTER_H
 
-// #include <doctest/doctest.h>
 #include <fstream>
+#include <streambuf>
 #include <string>
-#include "mpi.h"
+#include <mpi.h>
 
 
 #include <vector>

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -1,10 +1,9 @@
 #ifndef DOCTEST_MPI_SUB_COMM_H
 #define DOCTEST_MPI_SUB_COMM_H
 
-#include "mpi.h"
-#include "doctest/doctest.h"
 #include <cassert>
 #include <string>
+#include <mpi.h>
 
 namespace doctest {
 

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -1,5 +1,5 @@
-#ifndef DOCTEST_SUB_COMM_H
-#define DOCTEST_SUB_COMM_H
+#ifndef DOCTEST_MPI_SUB_COMM_H
+#define DOCTEST_MPI_SUB_COMM_H
 
 #include "mpi.h"
 #include "doctest/doctest.h"

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DOCTEST_SUB_COMM_H
+#define DOCTEST_SUB_COMM_H
 
 #include "mpi.h"
 #include "doctest/doctest.h"
@@ -79,3 +80,5 @@ struct mpi_sub_comm {
 };
 
 } // doctest
+
+#endif // DOCTEST_SUB_COMM_H


### PR DESCRIPTION
Added macro DOCTEST_CONFIG_IMPLEMENT_WITH_MPI_MAIN to provide a default main entry for mpi tests.