### PR TITLE
Use variables instead of hard-coded `mpirun` `-np`

### DIFF
--- a/examples/mpi/CMakeLists.txt
+++ b/examples/mpi/CMakeLists.txt
@@ -3,5 +3,5 @@ if(MPI_FOUND)
     add_executable(test_mpi main.cpp mpi.cpp)
     target_link_libraries(test_mpi doctest ${CMAKE_THREAD_LIBS_INIT} MPI::MPI_CXX)
 
-    doctest_add_test(NO_OUTPUT NAME test_mpi COMMAND mpirun -np 3 $<TARGET_FILE:test_mpi>)
+    doctest_add_test(NO_OUTPUT NAME test_mpi COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 $<TARGET_FILE:test_mpi>)
 endif()


### PR DESCRIPTION
## Description

CMake's [FindMPI](https://cmake.org/cmake/help/latest/module/FindMPI.html) module sets `MPIEXEC_EXECUTABLE` and `MPIEXEC_NUMPROC_FLAG`. We use them so it works for different MPI implementations.


