### PR TITLE
Fix CMake example in docs

### DIFF
--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -17,8 +17,8 @@ find_package(doctest REQUIRED)
 
 # Make test executable
 add_executable(tests main.cpp)
-target_compile_features(test PRIVATE cxx_std_17)
-target_link_libraries(test PRIVATE doctest::doctest)
+target_compile_features(tests PRIVATE cxx_std_17)
+target_link_libraries(tests PRIVATE doctest::doctest)
 ```
 
 - You can also use the following CMake snippet to automatically fetch the entire **doctest** repository from github and configure it as an external project:


### PR DESCRIPTION
Name of target is different from the name of executable. Therefore this example would fail in the generation phase.

<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
This pull request fixes the example for CMake provided in the documentation.
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->