### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -78,7 +78,7 @@ target_link_libraries(my_tests doctest)
         ./vcpkg integrate install
         ./vcpkg install doctest
       ```
-      The doctest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+      The doctest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request] on the [vcpkg repository](https://github.com/Microsoft/vcpkg).
 
 - hunter
 - conan

--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -69,7 +69,17 @@ target_link_libraries(my_tests doctest)
 
 **doctest** is available through the following package managers:
 
-- vcpkg
+- vcpkg    
+    - You can download and install doctest using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+      ```sh
+        git clone https://github.com/Microsoft/vcpkg.git
+        cd vcpkg
+        ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+        ./vcpkg integrate install
+        ./vcpkg install doctest
+      ```
+      The doctest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 - hunter
 - conan
     - https://conan.io/center/doctest


### PR DESCRIPTION
`doctest` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `doctest` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `doctest`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/doctest/portfile.cmake). We try to keep the library maintained as close as possible to the original library.