### PR TITLE
Fix compile errors when comparing pointers.

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1167,6 +1167,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+#if DOCTEST_GCC
+            __extension__
+#endif
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1168,10 +1168,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const void*>::fill(stream,
-#if DOCTEST_GCC
-                __extension__
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                reinterpret_cast<const void*>(in)
+#else
+                *reinterpret_cast<void* const*>(&in)
 #endif
-                reinterpret_cast<const void*>(in));
+            );
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1171,7 +1171,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
 #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
                 reinterpret_cast<const void*>(in)
 #else
-                *reinterpret_cast<void* const*>(&in)
+                *reinterpret_cast<const void* const*>(&in)
 #endif
             );
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1163,10 +1163,16 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
+        }
+    };
+
+    template <typename T, typename... Args>
+    struct filldata<T(*)(Args...)> {
+        static void fill(std::ostream* stream, T(*in)(Args...)) {
+            if (in) { *stream << in; }
+            else { *stream << "nullptr"; }
         }
     };
 }

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1167,10 +1167,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            filldata<const void*>::fill(stream,
 #if DOCTEST_GCC
-            __extension__
+                __extension__
 #endif
-            filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
+                reinterpret_cast<const void*>(in));
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1163,16 +1163,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
-        }
-    };
-
-    template <typename T, typename... Args>
-    struct filldata<T(*)(Args...)> {
-        static void fill(std::ostream* stream, T(*in)(Args...)) {
-            if (in) { *stream << in; }
-            else { *stream << "nullptr"; }
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };
 }

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1163,7 +1163,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
         }
     };

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1163,7 +1163,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     template <typename T>
     struct filldata<T*> {
         static void fill(std::ostream* stream, const T* in) {
-            filldata<const void*>::fill(stream, in);
+            filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
         }
     };
 }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1160,7 +1160,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     template <typename T>
     struct filldata<T*> {
         static void fill(std::ostream* stream, const T* in) {
-            filldata<const void*>::fill(stream, in);
+            filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
         }
     };
 }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1160,16 +1160,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
-        }
-    };
-
-    template <typename T, typename... Args>
-    struct filldata<T(*)(Args...)> {
-        static void fill(std::ostream* stream, T(*in)(Args...)) {
-            if (in) { *stream << in; }
-            else { *stream << "nullptr"; }
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };
 }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1164,6 +1164,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+#if DOCTEST_GCC
+            __extension__
+#endif
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1168,7 +1168,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
 #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
                 reinterpret_cast<const void*>(in)
 #else
-                *reinterpret_cast<void* const*>(&in)
+                *reinterpret_cast<const void* const*>(&in)
 #endif
             );
 DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1164,10 +1164,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            filldata<const void*>::fill(stream,
 #if DOCTEST_GCC
-            __extension__
+                __extension__
 #endif
-            filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
+                reinterpret_cast<const void*>(in));
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1160,7 +1160,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
         }
     };

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1160,10 +1160,16 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
             filldata<const void*>::fill(stream, reinterpret_cast<const void*>(in));
+        }
+    };
+
+    template <typename T, typename... Args>
+    struct filldata<T(*)(Args...)> {
+        static void fill(std::ostream* stream, T(*in)(Args...)) {
+            if (in) { *stream << in; }
+            else { *stream << "nullptr"; }
         }
     };
 }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1165,10 +1165,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const void*>::fill(stream,
-#if DOCTEST_GCC
-                __extension__
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                reinterpret_cast<const void*>(in)
+#else
+                *reinterpret_cast<void* const*>(&in)
 #endif
-                reinterpret_cast<const void*>(in));
+            );
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -250,13 +250,17 @@ TEST_CASE("a test case that registers an exception translator for int and then t
 }
 
 static void function() { }
+static int*** function2() { return nullptr; }
 
 TEST_CASE("pointer comparisons") {
-    auto a = new int();
-    auto b = a;
+    int i = 42;
+    int* a = &i;
+    int* b = a;
+    
     CHECK(a == b);
     CHECK_EQ(a, b);
 
     void (*functionPointer)() = &function;
     CHECK(&function == functionPointer);
+    CHECK(&function2 == &function2);
 }

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -248,3 +248,15 @@ TEST_CASE("a test case that registers an exception translator for int and then t
 
     throw_if(true, 5);
 }
+
+static void function() { }
+
+TEST_CASE("pointer comparisons") {
+    auto a = new int();
+    auto b = a;
+    CHECK(a == b);
+    CHECK_EQ(a, b);
+
+    void (*functionPointer)() = &function;
+    CHECK(&function == functionPointer);
+}

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 104 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 105 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -109,6 +109,7 @@
     <TestCase name="part of some TS" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite>
+    <TestCase name="pointer comparisons" filename="stringification.cpp" line="0" skipped="true"/>
     <TestCase name="reentering subcase via regular control flow" filename="subcases.cpp" line="0" skipped="true"/>
     <TestCase name="should fail and no output" filename="no_failures.cpp" line="0" should_fail="true" skipped="true"/>
     <TestCase name="should fail and no output" filename="test_cases_and_suites.cpp" line="0" should_fail="true" skipped="true"/>
@@ -148,6 +149,6 @@
     <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="104"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="105"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/no_multi_lane_atomics.txt
+++ b/examples/all_features/test_output/no_multi_lane_atomics.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  84 |  33 passed |  51 failed |
-[doctest] assertions: 230 | 110 passed | 120 failed |
+[doctest] test cases:  85 |  34 passed |  51 failed |
+[doctest] assertions: 233 | 113 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multi_lane_atomics.txt
+++ b/examples/all_features/test_output/no_multi_lane_atomics.txt
@@ -926,6 +926,6 @@ subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
 [doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 233 | 113 passed | 120 failed |
+[doctest] assertions: 234 | 114 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multithreading.txt
+++ b/examples/all_features/test_output/no_multithreading.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  84 |  33 passed |  51 failed |
-[doctest] assertions: 230 | 110 passed | 120 failed |
+[doctest] test cases:  85 |  34 passed |  51 failed |
+[doctest] assertions: 233 | 113 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multithreading.txt
+++ b/examples/all_features/test_output/no_multithreading.txt
@@ -926,6 +926,6 @@ subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
 [doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 233 | 113 passed | 120 failed |
+[doctest] assertions: 234 | 114 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/std_headers.txt
+++ b/examples/all_features/test_output/std_headers.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  84 |  33 passed |  51 failed |
-[doctest] assertions: 230 | 110 passed | 120 failed |
+[doctest] test cases:  85 |  34 passed |  51 failed |
+[doctest] assertions: 233 | 113 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/std_headers.txt
+++ b/examples/all_features/test_output/std_headers.txt
@@ -926,6 +926,6 @@ subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
 [doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 233 | 113 passed | 120 failed |
+[doctest] assertions: 234 | 114 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -91,6 +91,6 @@ stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
 [doctest] test cases:  6 |  3 passed |  3 failed |
-[doctest] assertions: 25 | 12 passed | 13 failed |
+[doctest] assertions: 26 | 13 passed | 13 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -90,7 +90,7 @@ TEST CASE:  a test case that registers an exception translator for int and then 
 stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
-[doctest] test cases:  5 | 2 passed |  3 failed |
-[doctest] assertions: 22 | 9 passed | 13 failed |
+[doctest] test cases:  6 |  3 passed |  3 failed |
+[doctest] assertions: 25 | 12 passed | 13 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="13" tests="25">
+  <testsuite name="all_features" errors="2" failures="13" tests="26">
     <testcase classname="double_stringification.cpp" name="toString std::string ret type" status="run"/>
     <testcase classname="stringification.cpp" name="operator&lt;&lt;" status="run"/>
     <testcase classname="stringification.cpp" name="no headers" status="run">

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="13" tests="22">
+  <testsuite name="all_features" errors="2" failures="13" tests="25">
     <testcase classname="double_stringification.cpp" name="toString std::string ret type" status="run"/>
     <testcase classname="stringification.cpp" name="operator&lt;&lt;" status="run"/>
     <testcase classname="stringification.cpp" name="no headers" status="run">
@@ -96,6 +96,7 @@ CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
         5
       </error>
     </testcase>
+    <testcase classname="stringification.cpp" name="pointer comparisons" status="run"/>
   </testsuite>
 </testsuites>
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -207,10 +207,10 @@
       <OverallResultsAsserts successes="0" failures="0" test_case_success="false"/>
     </TestCase>
     <TestCase name="pointer comparisons" filename="stringification.cpp" line="0">
-      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+      <OverallResultsAsserts successes="4" failures="0" test_case_success="true"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="12" failures="13"/>
+  <OverallResultsAsserts successes="13" failures="13"/>
   <OverallResultsTestCases successes="3" failures="3"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -206,8 +206,11 @@
       </Exception>
       <OverallResultsAsserts successes="0" failures="0" test_case_success="false"/>
     </TestCase>
+    <TestCase name="pointer comparisons" filename="stringification.cpp" line="0">
+      <OverallResultsAsserts successes="3" failures="0" test_case_success="true"/>
+    </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="9" failures="13"/>
-  <OverallResultsTestCases successes="2" failures="3"/>
+  <OverallResultsAsserts successes="12" failures="13"/>
+  <OverallResultsTestCases successes="3" failures="3"/>
 </doctest>
 Program code.


### PR DESCRIPTION
## Description

Since v2.4.9, pointers comparison will trigger a compile error inside `doctest` regarding pointer types. You can find reproduction examples and error messages in the issues referenced below.

This PR fixes that problem.

## GitHub Issues

Fixes #665, Fixes #675, Fixes #686
