### PR TITLE
Fix stringification of enums that overload `operator<<`

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1009,8 +1009,13 @@ namespace detail {
     struct has_insertion_operator : types::false_type { };
 #endif
 
-template <typename T>
-struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    template <typename T>
+    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+    template <typename T>
+    struct should_stringify_as_underlying_type {
+        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+    };
 
     DOCTEST_INTERFACE std::ostream* tlssPush();
     DOCTEST_INTERFACE String tlssPop();
@@ -1083,7 +1088,7 @@ String toString() {
 #endif
 }
 
-template <typename T, typename detail::types::enable_if<!detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
@@ -1119,7 +1124,7 @@ DOCTEST_INTERFACE String toString(long unsigned in);
 DOCTEST_INTERFACE String toString(long long in);
 DOCTEST_INTERFACE String toString(long long unsigned in);
 
-template <typename T, typename detail::types::enable_if<detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     using UT = typename detail::types::underlying_type<T>::type;
     return (DOCTEST_STRINGIFY(static_cast<UT>(value)));

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1006,8 +1006,13 @@ namespace detail {
     struct has_insertion_operator : types::false_type { };
 #endif
 
-template <typename T>
-struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    template <typename T>
+    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+    template <typename T>
+    struct should_stringify_as_underlying_type {
+        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+    };
 
     DOCTEST_INTERFACE std::ostream* tlssPush();
     DOCTEST_INTERFACE String tlssPop();
@@ -1080,7 +1085,7 @@ String toString() {
 #endif
 }
 
-template <typename T, typename detail::types::enable_if<!detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
@@ -1116,7 +1121,7 @@ DOCTEST_INTERFACE String toString(long unsigned in);
 DOCTEST_INTERFACE String toString(long long in);
 DOCTEST_INTERFACE String toString(long long unsigned in);
 
-template <typename T, typename detail::types::enable_if<detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     using UT = typename detail::types::underlying_type<T>::type;
     return (DOCTEST_STRINGIFY(static_cast<UT>(value)));

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -267,7 +267,7 @@ TEST_CASE("pointer comparisons") {
 
 enum class Foo { };
 
-std::ostream& operator<<(std::ostream& os, Foo) {
+static std::ostream& operator<<(std::ostream& os, Foo) {
     return os << "Foo";
 }
 

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -264,3 +264,13 @@ TEST_CASE("pointer comparisons") {
     CHECK(&function == functionPointer);
     CHECK(&function2 == &function2);
 }
+
+enum class Foo { };
+
+std::ostream& operator<<(std::ostream& os, Foo) {
+    return os << "Foo";
+}
+
+TEST_CASE("enum with operator<<") {
+    CHECK(doctest::toString(Foo()) == "Foo");
+}

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 105 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 106 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -48,6 +48,7 @@
   <TestSuite>
     <TestCase name="enum 1" filename="enums.cpp" line="0" skipped="true"/>
     <TestCase name="enum 2" filename="enums.cpp" line="0" should_fail="true" skipped="true"/>
+    <TestCase name="enum with operator&lt;&lt;" filename="stringification.cpp" line="0" skipped="true"/>
     <TestCase name="exceptions-related macros" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="exceptions-related macros for std::exception" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="exercising tricky code paths of doctest" filename="coverage_maxout.cpp" line="0" skipped="true"/>
@@ -149,6 +150,6 @@
     <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="105"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="106"/>
 </doctest>
 Program code.

--- a/examples/all_features/test_output/no_multi_lane_atomics.txt
+++ b/examples/all_features/test_output/no_multi_lane_atomics.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 234 | 114 passed | 120 failed |
+[doctest] test cases:  86 |  35 passed |  51 failed |
+[doctest] assertions: 235 | 115 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/no_multithreading.txt
+++ b/examples/all_features/test_output/no_multithreading.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 234 | 114 passed | 120 failed |
+[doctest] test cases:  86 |  35 passed |  51 failed |
+[doctest] assertions: 235 | 115 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/std_headers.txt
+++ b/examples/all_features/test_output/std_headers.txt
@@ -925,7 +925,7 @@ TEST CASE:  without a funny name:
 subcases.cpp(0): MESSAGE: Nooo
 
 ===============================================================================
-[doctest] test cases:  85 |  34 passed |  51 failed |
-[doctest] assertions: 234 | 114 passed | 120 failed |
+[doctest] test cases:  86 |  35 passed |  51 failed |
+[doctest] assertions: 235 | 115 passed | 120 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -90,7 +90,7 @@ TEST CASE:  a test case that registers an exception translator for int and then 
 stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
-[doctest] test cases:  6 |  3 passed |  3 failed |
-[doctest] assertions: 26 | 13 passed | 13 failed |
+[doctest] test cases:  7 |  4 passed |  3 failed |
+[doctest] assertions: 27 | 14 passed | 13 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="13" tests="26">
+  <testsuite name="all_features" errors="2" failures="13" tests="27">
     <testcase classname="double_stringification.cpp" name="toString std::string ret type" status="run"/>
     <testcase classname="stringification.cpp" name="operator&lt;&lt;" status="run"/>
     <testcase classname="stringification.cpp" name="no headers" status="run">
@@ -97,6 +97,7 @@ CHECK( "a" == doctest::Contains("aaa") ) is NOT correct!
       </error>
     </testcase>
     <testcase classname="stringification.cpp" name="pointer comparisons" status="run"/>
+    <testcase classname="stringification.cpp" name="enum with operator&lt;&lt;" status="run"/>
   </testsuite>
 </testsuites>
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -209,8 +209,11 @@
     <TestCase name="pointer comparisons" filename="stringification.cpp" line="0">
       <OverallResultsAsserts successes="4" failures="0" test_case_success="true"/>
     </TestCase>
+    <TestCase name="enum with operator&lt;&lt;" filename="stringification.cpp" line="0">
+      <OverallResultsAsserts successes="1" failures="0" test_case_success="true"/>
+    </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="13" failures="13"/>
-  <OverallResultsTestCases successes="3" failures="3"/>
+  <OverallResultsAsserts successes="14" failures="13"/>
+  <OverallResultsTestCases successes="4" failures="3"/>
 </doctest>
 Program code.


### PR DESCRIPTION
Fixes #678 