### PR TITLE
fix #707: syntax error with DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1299,9 +1299,9 @@ namespace detail {
     template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
     template<class T>               struct decay_array<T[]>  { using type = T*; };
 
-    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR value = 1; };
-    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR value = 0; };
-    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR value = 0; };
+    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR bool value = 1; };
+    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR bool value = 0; };
+    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR bool value = 0; };
 
     template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING


### PR DESCRIPTION
Closes #707

bug introduced with db758e027e735484d4e9b51da35ea737b0baec1d