### PR TITLE
Fix SUBCASE infinite loop

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1148,12 +1148,12 @@ namespace detail {
 
             if (!g_cs->reachedLeaf) {
                 // Leaf.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+                g_cs->fullyTraversedSubcases.insert(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)));
                 g_cs->nextSubcaseStack.clear();
                 g_cs->reachedLeaf = true;
             } else if (g_cs->nextSubcaseStack.empty()) {
                 // All children are finished.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+                g_cs->fullyTraversedSubcases.insert(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)));
             }
 
 #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)


### PR DESCRIPTION
* Insert and check same hash for fullyTraversedSubcases

<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Change the saved hash to match the hash later checked in the Subcase constructor.
This fixes an infinite loop that I encountered with at least two different nested SUBCASEs inside a loop.

```
TEST_CASE("Infinite")
{
  for (int idx = 0; idx < 2; ++idx)
  {
      SUBCASE("A")
      {
          SUBCASE("SUB A")
          {
              std::cout << "sub a" << std::endl;
          }
      }
      SUBCASE("B")
      {
          SUBCASE("SUB B")
          {
              std::cout << "sub b" << std::endl;
          }
      }
  }
}
```
