### PR TITLE
CMake: also install doctest/extensions/*.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,11 @@ if(NOT ${DOCTEST_NO_INSTALL})
         FILES "doctest/doctest.h"
         DESTINATION "${include_install_dir}/doctest"
     )
+    install(
+        DIRECTORY "doctest/extensions"
+        DESTINATION "${include_install_dir}/doctest"
+        FILES_MATCHING PATTERN "*.h"
+    )
 
     install(
         FILES "${project_config}" "${version_config}"


### PR DESCRIPTION
Header files in doctest/extensions are not installed by CMake. This PR fixes that