### PR TITLE
Fixed issue when including doctest directly using ExternalProject_Add

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ if(MAIN_PROJECT AND DOCTEST_WITH_TESTS)
     add_subdirectory(examples/mpi)
 endif()
 
+set(DOCTEST_CMAKE_HELPER "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/doctest.cmake" CACHE PATH "Absolute path to to doctest helper file. `include(${DOCTEST_CMAKE_HELPER})`")
+
 ################################################################################
 ## PACKAGE SUPPORT
 ################################################################################

--- a/scripts/cmake/doctest.cmake
+++ b/scripts/cmake/doctest.cmake
@@ -185,5 +185,7 @@ endfunction()
 ###############################################################################
 
 set(_DOCTEST_DISCOVER_TESTS_SCRIPT
-  ${CMAKE_CURRENT_LIST_DIR}/doctestAddTests.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/doctestAddTests.cmake
+    CACHE INTERNAL "The location of the doctestAddTests script"
 )
+mark_as_advanced(_DOCTEST_DISCOVER_TESTS_SCRIPT)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

WHAT: 
- Defined a cache variable called `DOCTEST_CMAKE_HELPER` to allow projects that include Doctest via ExternalProject to access the script without rooting around in the guts of the project
- Made `_DOCTEST_DISCOVER_TESTS_SCRIPT` a CACHE variable - fixing a bug where tests would not be built

WHY:
It appears that Doctest is really well set up for the `install` method of inclusion in cmake. However, I include cmake in my project directly using:

```
FetchContent_Declare(
    _doctest
    URL ${CMAKE_CURRENT_SOURCE_DIR}/doctest/doctest-ae7a13539fb71f270b87eb2e874fbac80bc8dda2.zip
)
FetchContent_MakeAvailable(_doctest)

```

When this happens, if I want the (very very useful) `doctest_discover_tests` to be available, I have to do something gross, such as:

```
include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
```

Part one of this change allows for 
```
include(${DOCTEST_CMAKE_HELPER})
```


Secondly (and the much bigger thing, because it was a bug preventing my tests from being built) is that when this file is included, it evaluates setting the variable:

```
set(_DOCTEST_DISCOVER_TESTS_SCRIPT
  ${CMAKE_CURRENT_LIST_DIR}/doctestAddTests.cmake
)
```

This variable is ONLY set for the parent scope, so when I include this script, then later in another file I attempt to use `doctest_discover_tests`, this variable was no longer set, leading to `mytestname_NOTBUILT can't be run` in ctest.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
