### PR TITLE
Suppress Clang 16 warnings. Closes #766

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,6 +212,10 @@ jobs:
             compiler: clang
             version: "15"
 
+          - os: ubuntu-latest
+            compiler: clang
+            version: "16"
+
           - os: macOS-10.15
             compiler: xcode
             version: "10.3"
@@ -245,11 +249,13 @@ jobs:
 
           # clang-3.7 and earlier are not available in Bionic anymore so we get
           # them from the Xenial repositories instead.
-          sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
-          sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-          #sudo sh -c 'wget -q -O - "https://keyserver.ubuntu.com/pks/lookup?search=0x40976EAF437D05B5&fingerprint=on&op=get" | gpg -q --dearmor - | tee "/usr/share/keyrings/dk.gpg" > /dev/null'
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
+          if bash -c '[[ "${{ matrix.compiler }}" = "clang" && ${{ matrix.version }} = 3.* ]]'; then
+            sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+            sudo gpg --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+            #sudo sh -c 'wget -q -O - "https://keyserver.ubuntu.com/pks/lookup?search=0x40976EAF437D05B5&fingerprint=on&op=get" | gpg -q --dearmor - | tee "/usr/share/keyrings/dk.gpg" > /dev/null'
+            sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
+            sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
+          fi
 
           # clang->=13 is not currently available by default
           # causing compiler conflict for clang-14 as the below pulls from focal for 22.04 (ubuntu-latest)
@@ -257,6 +263,16 @@ jobs:
             #wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             #sudo add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.version }} main"
           #fi
+
+          # Add Clang repos if we don't have the necessary package by default.
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            if ! apt-cache show clang-${{ matrix.version }} >/dev/null 2>/dev/null; then
+              wget https://apt.llvm.org/llvm.sh
+              chmod +x llvm.sh
+              sudo ./llvm.sh ${{ matrix.version }}
+              rm llvm.sh
+            fi
+          fi
 
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
@@ -372,4 +388,3 @@ jobs:
         run: |
           . /opt/intel/oneapi/setvars.sh
           ctest -C ${{ matrix.configuration }} --test-dir build --no-tests=error
-

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -167,6 +167,7 @@
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16                                                 \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
@@ -205,6 +206,13 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
     DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
     DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
+
+#if DOCTEST_CLANG >= DOCTEST_COMPILER(16, 0, 0)
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16 \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")
+#else
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16
+#endif
 
 #define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -164,6 +164,7 @@
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16                                                 \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
@@ -202,6 +203,13 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
     DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
     DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
+
+#if DOCTEST_CLANG >= DOCTEST_COMPILER(16, 0, 0)
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16 \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")
+#else
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_GROUP_CLANG16
+#endif
 
 #define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -184,6 +184,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compiler_flags(-Wno-c++98-compat-bind-to-temporary-copy)
     add_compiler_flags(-Wno-c++98-compat-local-type-template-args)
     add_compiler_flags(-Qunused-arguments -fcolor-diagnostics) # needed for ccache integration
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0)
+        add_compiler_flags(-Wno-unsafe-buffer-usage)
+    endif()
 endif()
 
 if(MSVC)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

**What:** Silence Clang 16's `-Wunsafe-buffer-usage`.
**Why:** That + `-Werror` causes build errors in the examples.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
https://github.com/doctest/doctest/issues/766
