### PR TITLE
Only call subcase_end currentSubcaseDepth times

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -4885,10 +4885,10 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
-            g_cs->subcaseStack.pop_back();
+        for(size_t i = 0; i < g_cs->currentSubcaseDepth; i++) {
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
         }
+        g_cs->subcaseStack.clear();
 
         g_cs->finalizeTestCaseData();
 

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1795,10 +1795,10 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
-            g_cs->subcaseStack.pop_back();
+        for(size_t i = 0; i < g_cs->currentSubcaseDepth; i++) {
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
         }
+        g_cs->subcaseStack.clear();
 
         g_cs->finalizeTestCaseData();
 


### PR DESCRIPTION
Fix #803, presumably this has been broken since #598.

