### PR TITLE
Bump minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)


### PR DESCRIPTION
Compatibility with CMake < 3.5 will be removed in future versions of CMake, so this avoids the warning and the impending doom.

## Description

Recent CMake versions are warning that compatibility with CMake < 3.5 will be removed in a future version. Building the project will yield a warning:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

I dug around the changelogs from 3.1->3.5 to see if there's anything relevant policy-wise that changes but couldn't find much and the doctest CMakeLists.txt is already pretty simple. I also tested it locally, and everything can still build.

I only bumped it to 3.5, which came out in 2016 but most projects I've seen set it to somewhere around ~3.16. If this is too conservative, then I can bump it up higher.

## GitHub Issues

Surprisingly, I couldn't find any!