### PR TITLE
Fix exporting of Targets.cmake for include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(NOT ${DOCTEST_NO_INSTALL})
     install(
         TARGETS ${PROJECT_NAME}
         EXPORT "${targets_export_name}"
-        INCLUDES DESTINATION "${include_install_dir}"
+        INCLUDES DESTINATION "${include_install_dir}/doctest"
     )
 
     install(


### PR DESCRIPTION
## Description

Building main example from Readme via CMake ([CMakeLists.txt](https://github.com/doctest/doctest/files/12709453/CMakeLists.txt)) using `doctestTargets.cmake` causes an error.

```
boris@boris:~/doctest% cmake --build .
[ 50%] Building CXX object CMakeFiles/main.dir/main.cpp.o
/home/boris/doctest/main.cpp:2:10: fatal error: 'doctest.h' file not found
#include "doctest.h"
         ^~~~~~~~~~~
1 error generated.
gmake[2]: *** [CMakeFiles/main.dir/build.make:76: CMakeFiles/main.dir/main.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/main.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

Proposed patch specifies `doctest` directory explicit for `INCLUDES DESTINATION`.

Main example builds with the patched `doctestTargets.cmake` successful.

## GitHub Issues
For #175.