### PR TITLE
Expose include directory as system path via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(MAIN_PROJECT)
 
     add_custom_target(assemble_single_header ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/doctest/doctest.h)
 else()
-    target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
+    target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
## Description
Treading the include directory as a system include directory prevents clang-tidy from emitting errors from the doctest headers, avoiding issues when using various doctest macros.
