### PR TITLE
update docs to use the newer FetchContent instead of the older ExternalProject_Add

### DIFF
--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -24,34 +24,32 @@ target_link_libraries(tests PRIVATE doctest::doctest)
 - You can also use the following CMake snippet to automatically fetch the entire **doctest** repository from github and configure it as an external project:
 
 ```cmake
-include(ExternalProject)
-find_package(Git REQUIRED)
-
-ExternalProject_Add(
-    doctest
-    PREFIX ${CMAKE_BINARY_DIR}/doctest
-    GIT_REPOSITORY https://github.com/doctest/doctest.git
-    TIMEOUT 10
-    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
+include(FetchContent)
+FetchContent_Declare(
+  doctest
+  GIT_REPOSITORY https://github.com/doctest/doctest
+  GIT_TAG master # or any commit SHA, branch name or tag like v2.4.11
 )
+FetchContent_MakeAvailable(doctest)
 
-# Expose required variable (DOCTEST_INCLUDE_DIR) to parent scope
-ExternalProject_Get_Property(doctest source_dir)
-set(DOCTEST_INCLUDE_DIR ${source_dir}/doctest CACHE INTERNAL "Path to include folder for doctest")
+# Include doctest_discover_tests(<target>) function
+include("${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake")
 ```
 
-And later you'll be able to use the doctest include directory like this:
+The target `doctest::doctest` is now exposed at the global scope and later you'll be able to use the doctest target like this:
 
 ```cmake
-# add it globally
-include_directories(${DOCTEST_INCLUDE_DIR})
+# Link doctest to a target
+target_link_libraries(my_target PUBLIC doctest::doctest)
 
-# or per target
-target_include_directories(my_target PUBLIC ${DOCTEST_INCLUDE_DIR})
+# Or link it globally
+link_libraries(doctest::doctest)
+```
+
+Access the doctest headers with a scoped `#include` directive:
+
+```c++
+#include "doctest/doctest.h"
 ```
 
 - If you have the entire doctest repository available (as a submodule or just as files) you could also include it in your CMake build by using ```add_subdirectory(path/to/doctest)``` and then you could use it like this:


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Updated the documentation for using doctest with CMake via the newer `FetchContent` instead of the older `ExternalProject_Add`.

I was looking for this exact documentation and was unable to find it in the docs. I did find #698 with the information I wanted but it was a year old so I made the PR myself. 
## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #698