### PR TITLE
Using CHECK with bitfield fails to compile #786

### DIFF
--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1575,8 +1575,8 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // https://github.com/catchorg/Catch2/issues/870
         // https://github.com/catchorg/Catch2/issues/565
         template <typename L>
-        Expression_lhs<L> operator<<(L&& operand) {
-            return Expression_lhs<L>(static_cast<L&&>(operand), m_at);
+        Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
+            return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
         }
 
         template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -24,6 +24,8 @@ set(files_all
     ${files_with_output}
     concurrency.cpp
     coverage_maxout.cpp
+    bitfields.cpp
+    bitfield_packed_struct.cpp
     namespace1.cpp
     namespace2.cpp
     namespace3.cpp
@@ -61,6 +63,8 @@ if(NOT MINGW AND NOT DEFINED DOCTEST_THREAD_LOCAL)
     doctest_add_test(NO_OUTPUT NAME concurrency.cpp ${common_args} -sf=*concurrency.cpp -d) # duration: there is no output anyway
 endif()
 
+doctest_add_test(NO_OUTPUT NAME bitfield_packed_struct.cpp ${common_args} -sf=*bitfield_packed_struct.cpp.cpp )
+doctest_add_test(NO_OUTPUT NAME bitfields.cpp ${common_args} -sf=*bitfields.cpp )
 doctest_add_test(NO_OUTPUT NAME namespace1.cpp ${common_args} -sf=*namespace1.cpp )
 doctest_add_test(NO_OUTPUT NAME namespace2.cpp ${common_args} -sf=*namespace2.cpp )
 doctest_add_test(NO_OUTPUT NAME namespace3.cpp ${common_args} -sf=*namespace3.cpp )

--- a/examples/all_features/bitfield_packed_struct.cpp
+++ b/examples/all_features/bitfield_packed_struct.cpp
@@ -8,6 +8,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
 
+#ifndef WIN32
 struct __attribute__((packed)) P {
     int i;
 };
@@ -17,3 +18,4 @@ TEST_CASE("packed_struct") {
     CHECK(p.i == 0); // error: cannot bind packed field ‘s.S::i’ to ‘int&’
     //CHECK(int(s.i) == 0); // 'useless cast'
 }
+#endif

--- a/examples/all_features/bitfield_packed_struct.cpp
+++ b/examples/all_features/bitfield_packed_struct.cpp
@@ -1,0 +1,19 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+struct __attribute__((packed)) P {
+    int i;
+};
+TEST_CASE("packed_struct") {
+    P p;
+    p.i = 0;
+    CHECK(p.i == 0); // error: cannot bind packed field ‘s.S::i’ to ‘int&’
+    //CHECK(int(s.i) == 0); // 'useless cast'
+}

--- a/examples/all_features/bitfields.cpp
+++ b/examples/all_features/bitfields.cpp
@@ -1,0 +1,20 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+struct S {
+    uint32_t a : 31;
+    uint32_t b : 1;
+};
+TEST_CASE("bitfield") {
+    S s;
+    s.a = 0;
+    s.b = 1;
+    CHECK(s.a == 0); // error here
+}

--- a/examples/all_features/decomposition.cpp
+++ b/examples/all_features/decomposition.cpp
@@ -9,7 +9,7 @@ class MoveOnly {
         MoveOnly& operator=(const MoveOnly&) = default;
         ~MoveOnly() = default;
         // NOLINTNEXTLINE(readability-make-member-function-const)
-        operator bool() { // NOT const!
+        operator bool() const { // both non-const and const can call
             return i == 42;
         }
 

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 106 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 108 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -30,6 +30,7 @@
     <TestCase name="all binary assertions" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="an empty test that will succeed - not part of a test suite" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
     <TestCase name="bad stringification of type pair&lt;int_pair>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
+    <TestCase name="bitfield" filename="bitfields.cpp" line="0" skipped="true"/>
     <TestCase name="check return values" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="check return values no print" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="custom macros" filename="alternative_macros.cpp" line="0" skipped="true"/>
@@ -101,6 +102,7 @@
   </TestSuite>
   <TestSuite>
     <TestCase name="operator&lt;&lt;" filename="stringification.cpp" line="0" skipped="true"/>
+    <TestCase name="packed_struct" filename="bitfield_packed_struct.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite name="scoped test suite">
     <TestCase name="part of scoped" filename="test_cases_and_suites.cpp" line="0" skipped="true"/>
@@ -150,6 +152,6 @@
     <TestCase name="without a funny name:" filename="subcases.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="106"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="108"/>
 </doctest>
 Program code.


### PR DESCRIPTION
Use rvalue reference instead of universal reference so that bitfields bind to const lvalue




