### PR TITLE
Allow constructing doctest::String from anything with .data() and .size() members

### DIFF
--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -621,6 +621,8 @@ public:
     // cppcheck-suppress noExplicitConstructor
     String(const char* in);
     String(const char* in, size_type in_size);
+    template <class S>
+    String(const S & str) : String(str.data(), str.size() {}
 
     String(std::istream& in, size_type in_size);
 


### PR DESCRIPTION
## Description
Most obvious of these are std::string and std::string_view, and this is naturally useful for stringification implementations which otherwise need to extract the size explicitly.