### PR TITLE
Add a doctest.pc pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     include(GNUInstallDirs)
     set(include_install_dir ${CMAKE_INSTALL_INCLUDEDIR})
     set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    set(pkg_config_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 else()
     set(include_install_dir "include")
     set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+    set(pkg_config_install_dir "lib/pkgconfig")
 endif()
 
 
@@ -135,6 +137,9 @@ set(CMAKE_SIZEOF_VOID_P ${DOCTEST_SIZEOF_VOID_P})
 
 configure_file("scripts/cmake/Config.cmake.in" "${project_config}" @ONLY)
 
+set (project_pkg_config "${generated_dir}/${PROJECT_NAME}.pc")
+configure_file("doctest.pc.in" "${project_pkg_config}" @ONLY)
+
 if(NOT ${DOCTEST_NO_INSTALL})
     install(
         TARGETS ${PROJECT_NAME}
@@ -155,6 +160,11 @@ if(NOT ${DOCTEST_NO_INSTALL})
     install(
         FILES "${project_config}" "${version_config}"
         DESTINATION "${config_install_dir}"
+    )
+
+    install(
+        FILES "${project_pkg_config}"
+        DESTINATION "${pkg_config_install_dir}"
     )
 
     install(

--- a/doctest.pc.in
+++ b/doctest.pc.in
@@ -1,0 +1,10 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: The fastest feature-rich C++11/14/17/20/23 single-header testing framework
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -ldoctest
+Cflags: -I${includedir}


### PR DESCRIPTION
## Description

This PR adds a `doctest.pc` file, which is generated and installed in a similar way to `doctestConfig.cmake`.

## GitHub Issues

See https://github.com/doctest/doctest/issues/850 for rationale and existing discussion.
