### PR TITLE
Bump minimum cmake and replace <ciso646> with <version>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.25)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -9,7 +9,7 @@ You can substitute ```master``` with ```dev``` or a tag like ```v1.4.8``` for a 
 - **doctest** is easiest to use as a single file inside your own repository. Then the following minimal example will work:
 
 ```cmake
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.25)
 project(cmake_test VERSION 0.0.1 LANGUAGES CXX)
 
 # Prepare doctest for other targets to use

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -496,7 +496,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 // https://github.com/doctest/doctest/issues/126
 // https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
-#include <ciso646>
+#include <version>
 #endif // clang
 
 #ifdef _LIBCPP_VERSION

--- a/examples/exe_with_static_libs/doctest_force_link_static_lib_in_target.cmake
+++ b/examples/exe_with_static_libs/doctest_force_link_static_lib_in_target.cmake
@@ -3,7 +3,7 @@ if(doctest_force_link_static_lib_in_target_included)
 endif()
 set(doctest_force_link_static_lib_in_target_included true)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.25)
 
 # includes the file to the source with compiler flags
 function(doctest_include_file_in_sources header sources)

--- a/examples/installed_doctest_cmake/dll/CMakeLists.txt
+++ b/examples/installed_doctest_cmake/dll/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.25)
 
 project(example_dll VERSION 0.0.1 LANGUAGES CXX)
 

--- a/examples/installed_doctest_cmake/executable/CMakeLists.txt
+++ b/examples/installed_doctest_cmake/executable/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.25)
 
 project(example_exe VERSION 0.0.1 LANGUAGES CXX)
 

--- a/scripts/how_stuff_works/CMakeLists.txt
+++ b/scripts/how_stuff_works/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.25)
 
 project(how_stuff_works)
 


### PR DESCRIPTION
To support newer cmake versions without warning, we could bump the minimum version usage in this repo. 

Also ciso646 has been deprecated and replaced with version as of c++20. See this for context:
https://en.cppreference.com/w/cpp/header/ciso646