### PR TITLE
Split toString(String) into && and const& overloads

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1108,6 +1108,8 @@ String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
 
+inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1117,7 +1119,7 @@ DOCTEST_INTERFACE String toString(const char* in);
 DOCTEST_INTERFACE String toString(const std::string& in);
 #endif // VS 2019
 
-DOCTEST_INTERFACE String toString(String in);
+DOCTEST_INTERFACE String toString(const String& in);
 
 DOCTEST_INTERFACE String toString(std::nullptr_t);
 
@@ -3962,7 +3964,7 @@ String toString(const char* in) { return String("\"") + (in ? in : "{null string
 String toString(const std::string& in) { return in.c_str(); }
 #endif // VS 2019
 
-String toString(String in) { return in; }
+String toString(const String& in) { return in; }
 
 String toString(std::nullptr_t) { return "nullptr"; }
 

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -871,7 +871,7 @@ String toString(const char* in) { return String("\"") + (in ? in : "{null string
 String toString(const std::string& in) { return in.c_str(); }
 #endif // VS 2019
 
-String toString(String in) { return in; }
+String toString(const String& in) { return in; }
 
 String toString(std::nullptr_t) { return "nullptr"; }
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1105,6 +1105,8 @@ String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
 
+inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1114,7 +1116,7 @@ DOCTEST_INTERFACE String toString(const char* in);
 DOCTEST_INTERFACE String toString(const std::string& in);
 #endif // VS 2019
 
-DOCTEST_INTERFACE String toString(String in);
+DOCTEST_INTERFACE String toString(const String& in);
 
 DOCTEST_INTERFACE String toString(std::nullptr_t);
 


### PR DESCRIPTION
This reduces the cost of DOCTEST_CONFIG_DOUBLE_STRINGIFY to effectively nothing.