### PR TITLE
Add filldata for volatile pointers

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1195,6 +1195,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
         static void fill(std::ostream* stream, const void* in);
     };
 
+    template <>
+    struct filldata<const volatile void*> {
+        static void fill(std::ostream* stream, const volatile void* in);
+    };
+
     template <typename T>
     struct filldata<T*> {
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
@@ -1206,6 +1211,23 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
                 reinterpret_cast<const void*>(in)
 #else
                 *reinterpret_cast<const void* const*>(&in)
+#endif
+            );
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+        }
+    };
+
+    template <typename T>
+    struct filldata<volatile T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
+        static void fill(std::ostream* stream, const volatile T* in) {
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            filldata<const volatile void*>::fill(stream,
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                reinterpret_cast<const volatile void*>(in)
+#else
+                *reinterpret_cast<const volatile void* const*>(&in)
 #endif
             );
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
@@ -3947,6 +3969,11 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 namespace detail {
     void filldata<const void*>::fill(std::ostream* stream, const void* in) {
+        if (in) { *stream << in; }
+        else { *stream << "nullptr"; }
+    }
+
+    void filldata<const volatile void*>::fill(std::ostream* stream, const volatile void* in) {
         if (in) { *stream << in; }
         else { *stream << "nullptr"; }
     }


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
Fix for comparing `volatile` pointers.
```cpp
#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
#include <doctest/doctest.h>

TEST_CASE("") {
    SUBCASE("") {
        volatile int arr[] = { 1, 2, 3 };
        auto begin = &(*arr);
        REQUIRE(&(*arr) == &(*begin)); //  <-- fails
    }
}
```
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
Fixes https://github.com/doctest/doctest/issues/933
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
