### PR TITLE
fix: Suppress -Wunsafe-buffer-usage for clang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,6 +294,12 @@ jobs:
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
           elif [ "${{ matrix.compiler }}" = "clang" ]; then
+            # clang-17 does not automatically provide the i386 sanitizer runtimes,
+            # but libclang-rt-V-dev:i386 does not always exist. This is the best intermediate option
+            if [ "${{ matrix.version }}" = "17" ]; then
+              sudo apt-get install -y libclang-rt-${{ matrix.version }}-dev:i386
+            fi
+
             sudo apt-get install -y clang-${{ matrix.version }} libclang-${{ matrix.version }}-dev llvm-${{ matrix.version }}-dev g++-multilib
           fi
 

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -162,11 +162,13 @@
 #define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                        \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -159,11 +159,13 @@
 #define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                        \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -1,4 +1,5 @@
 include(CMakeParseArguments)
+include(CheckCXXCompilerFlag)
 
 # cache this for use inside of the function
 set(CURRENT_LIST_DIR_CACHED ${CMAKE_CURRENT_LIST_DIR})
@@ -187,6 +188,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compiler_flags(-Wno-c++98-compat-bind-to-temporary-copy)
     add_compiler_flags(-Wno-c++98-compat-local-type-template-args)
     add_compiler_flags(-Qunused-arguments -fcolor-diagnostics) # needed for ccache integration
+endif()
+
+check_cxx_compiler_flag(-Wunsafe-buffer-usage HAVE_UNSAFE_BUFFER_USAGE)
+if(HAVE_UNSAFE_BUFFER_USAGE)
+    add_compiler_flags(-Wno-unsafe-buffer-usage)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Adds `-Wunknown-warning-option` and `-Wunsafe-buffer-usage` to the common-warnings list.
Since `-Wunsafe-buffer-usage` was added from clang-16 onwards, older versions of `clang` will (rightfully) warn if they see a suppression for it. 
`-Wunknown-warning-option` prevents this, but it is a bit of a blanket fix, since we won't get warnings for incorrect cases like `-Wtf`.
However, it seems that `gcc` is already configured this way, so maybe not the worst option?

Long-run, it would be good to reduce the number of warnings we're globally turning off, since it makes our claim of "compiles without warnings" a little less interesting.

## GitHub Issues

Closes #766 

<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
