### PR TITLE
ci(windows): switch to windows 2025 image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -368,7 +368,7 @@ jobs:
             python3 .github/workflows/build_and_test.py ${{ runner.os }} x86 ${{ matrix.compiler }} ${{ matrix.version }}
         run: docker exec build-container bash -c "$CMD"
 
-  ci-min-gw:
+  ci-mingw-w64:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-latest
 
@@ -380,8 +380,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up MinGW
+      - name: Set up MinGW-w64
         uses: egor-tensin/setup-mingw@v2
+        with:
+          version: 12.2.0
 
       - name: Generate
         run: cmake -B build -S . -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE=${{ matrix.configuration }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-2019", "windows-2022"]
+        os: ["windows-2025"]
         compiler: ["cl", "clang", "clang-cl"]
 
         include:
@@ -394,12 +394,12 @@ jobs:
 
   ci-msvs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ${{ matrix.toolset == 'v143' && 'windows-2022' || 'windows-2019' }}
+    runs-on:  "windows-2025"
 
     strategy:
       fail-fast: false
       matrix:
-        toolset: ["v140", "v141", "v142", "v143", "ClangCl"]
+        toolset: ["v142", "v143"]
         architecture: ["Win32", "x64"]
         configuration: ["Debug", "Release"]
 
@@ -408,7 +408,7 @@ jobs:
 
       - name: Generate
         run:
-          cmake -B build -S . -G "${{ matrix.toolset == 'v143' && 'Visual Studio 17 2022' || 'Visual Studio 16 2019' }}" \
+          cmake -B build -S . -G "Visual Studio 17 2022" \
           -A ${{ matrix.architecture }} -T ${{ matrix.toolset }}
 
       - name: Build


### PR DESCRIPTION
## Description

### Added configurations

* Windows Server 2025

### Removed configurations

* Windows Server 2019
* Windows Server 2022

### Additional changes

* removed duplication of Clang runs on Windows
* removed platform toolsets not supported by Visual Studio 17 2022
* switch to version 12.2.0 of MinGW-w64 due to incompatibilities with version 13.0

## GitHub Issues

Part of #871