### PR TITLE
ci(macOS): use macOS 14 with XCode 15.4 for GCC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,7 @@ jobs:
             compiler: xcode
             version: "16.3" # Apple Clang 17.0.0
 
-          - os: macos-15
+          - os: macos-14
             compiler: gcc
             version: "12"
 
@@ -327,7 +327,7 @@ jobs:
             sudo xcode-select --switch /Applications/Xcode_${{ matrix.version }}.app
           fi
 
-          if [ "${{ matrix.os}}" = "macos-15" -a "${{ matrix.compiler }}" = "gcc" ]; then
+          if [ "${{ matrix.os}}" = "macos-14" -a "${{ matrix.compiler }}" = "gcc" ]; then
             sudo xcode-select --switch /Applications/Xcode_15.4.app
           fi
 


### PR DESCRIPTION
## Description

XCode on macOS 15 was updated, the default version is now Xcode 16 which is incompatible with GCC, so we need to switch to macOS 14 with still uses Xcode 15.

## GitHub Issues

Part of #871
