### PR TITLE
chore: Remove type-hinting from scripts/assemble.py for Python3.6 compat

### DIFF
--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -13,15 +13,12 @@ the final doctest.h header.
 # ///
 
 
-from __future__ import annotations
-
 import re
 import string
 import sys
 from itertools import chain
 from pathlib import Path
 from textwrap import dedent
-from typing import Generator, NoReturn
 
 
 TEMPLATE = string.Template(
@@ -40,7 +37,7 @@ TEMPLATE = string.Template(
 )
 
 
-def main(args: list[str]) -> NoReturn:
+def main(args):
     """Script entry-point."""
 
     if len(args) != 1:
@@ -57,7 +54,7 @@ def main(args: list[str]) -> NoReturn:
     headers = set(header_dir.rglob("*.h"))
     sources = set(source_dir.rglob("*.cpp"))
 
-    def extract_header(line: str) -> str | None:
+    def extract_header(line):
         """
         Extract a header file name from a line of C code.
 
@@ -80,7 +77,7 @@ def main(args: list[str]) -> NoReturn:
         reason = f"'{line}' has multiple includes"
         raise RuntimeError(reason)
 
-    def process_file(file: Path, visited: set[Path]) -> Generator[str, None, None]:
+    def process_file(file, visited):
         """
         Process a file, yielding lines of code with #include's scrubbed.
 
@@ -110,7 +107,7 @@ def main(args: list[str]) -> NoReturn:
             else:
                 yield line
 
-    visited: set[Path] = set()
+    visited = set()
     result = TEMPLATE.substitute(
         headers="\n".join(
             chain.from_iterable(process_file(file, visited=visited) for file in headers)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description

Removes type-hints from `scripts/assemble.py`, as `from __future__ import annotations` support was only added from Python3.7 onwards. We could re-add these in the future by bumping the Python version on the CI, but I'd like to stabilize the CI first before doing much hacking in there.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues

#914
