### PR TITLE
feat: honor FORCE_COLOR and NO_COLOR environment variables (#923)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5782,6 +5782,19 @@ void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
         p->list_reporters = true;
         p->exit = true;
     }
+
+#ifndef DOCTEST_CONFIG_COLORS_NONE
+    if (withDefaults) {
+        if (const char* no_color = std::getenv("NO_COLOR")) {
+            if (no_color[0] != '\0')
+                p->no_colors = true;
+        }
+        if (const char* force_color = std::getenv("FORCE_COLOR")) {
+            if (force_color[0] != '\0' && !(force_color[0] == '0' && force_color[1] == '\0'))
+                p->force_colors = true;
+        }
+    }
+#endif
 }
 
 // allows the user to add procedurally to the filters from the command line

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -354,6 +354,19 @@ void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
         p->list_reporters = true;
         p->exit = true;
     }
+
+#ifndef DOCTEST_CONFIG_COLORS_NONE
+    if (withDefaults) {
+        if (const char* no_color = std::getenv("NO_COLOR")) {
+            if (no_color[0] != '\0')
+                p->no_colors = true;
+        }
+        if (const char* force_color = std::getenv("FORCE_COLOR")) {
+            if (force_color[0] != '\0' && !(force_color[0] == '0' && force_color[1] == '\0'))
+                p->force_colors = true;
+        }
+    }
+#endif
 }
 
 // allows the user to add procedurally to the filters from the command line


### PR DESCRIPTION
## Description
Honor `FORCE_COLOR` / `NO_COLOR` when deciding whether to emit ANSI colors.

## GitHub Issue
Closes #923

## Type
- [x] Feature addition

## Notes
I used coding tools for some of the boilerplate; the behavior and tests are what I intended to land.

## Checklist
- [x] Targets `dev`
- [x] Edits under `doctest/parts/*` (header reassembled)
