### PR TITLE
feat(approx): add Catch2-compatible margin() absolute tolerance (#389)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1359,6 +1359,16 @@ struct DOCTEST_INTERFACE Approx {
     }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
+    Approx &margin(double newMargin);
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template <typename T>
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type margin(const T &newMargin) {
+        m_margin = static_cast<double>(newMargin);
+        return *this;
+    }
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
     Approx &scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
@@ -1407,6 +1417,7 @@ struct DOCTEST_INTERFACE Approx {
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     double m_epsilon;
+    double m_margin;
     double m_scale;
     double m_value;
 };
@@ -6508,13 +6519,22 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
+namespace {
+// Performs equivalent check of std::fabs(lhs - rhs) <= margin
+// But without the subtraction to allow for INFINITY in comparison
+bool marginComparison(double lhs, double rhs, double margin) {
+    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+}
+} // namespace
 
 Approx::Approx(double value)
-    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_margin(0.0), m_scale(1.0),
+      m_value(value) {}
 
 Approx Approx::operator()(double value) const {
     Approx approx(value);
     approx.epsilon(m_epsilon);
+    approx.margin(m_margin);
     approx.scale(m_scale);
     return approx;
 }
@@ -6523,15 +6543,21 @@ Approx &Approx::epsilon(double newEpsilon) {
     m_epsilon = newEpsilon;
     return *this;
 }
+Approx &Approx::margin(double newMargin) {
+    m_margin = newMargin;
+    return *this;
+}
 Approx &Approx::scale(double newScale) {
     m_scale = newScale;
     return *this;
 }
 
 bool operator==(double lhs, const Approx &rhs) {
-    // Thanks to Richard Harris for his help refining this formula
-    return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
+    // Absolute margin OR scaled epsilon (Catch2-style).
+    // Thanks to Richard Harris for his help refining the scaled epsilon formula
+    return marginComparison(lhs, rhs.m_value, rhs.m_margin) ||
+           std::fabs(lhs - rhs.m_value) <
+               rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 
 bool operator==(const Approx &lhs, double rhs) {

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -3,13 +3,22 @@
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
+namespace {
+// Performs equivalent check of std::fabs(lhs - rhs) <= margin
+// But without the subtraction to allow for INFINITY in comparison
+bool marginComparison(double lhs, double rhs, double margin) {
+    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+}
+} // namespace
 
 Approx::Approx(double value)
-    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_margin(0.0), m_scale(1.0),
+      m_value(value) {}
 
 Approx Approx::operator()(double value) const {
     Approx approx(value);
     approx.epsilon(m_epsilon);
+    approx.margin(m_margin);
     approx.scale(m_scale);
     return approx;
 }
@@ -18,15 +27,21 @@ Approx &Approx::epsilon(double newEpsilon) {
     m_epsilon = newEpsilon;
     return *this;
 }
+Approx &Approx::margin(double newMargin) {
+    m_margin = newMargin;
+    return *this;
+}
 Approx &Approx::scale(double newScale) {
     m_scale = newScale;
     return *this;
 }
 
 bool operator==(double lhs, const Approx &rhs) {
-    // Thanks to Richard Harris for his help refining this formula
-    return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
+    // Absolute margin OR scaled epsilon (Catch2-style).
+    // Thanks to Richard Harris for his help refining the scaled epsilon formula
+    return marginComparison(lhs, rhs.m_value, rhs.m_margin) ||
+           std::fabs(lhs - rhs.m_value) <
+               rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 
 bool operator==(const Approx &lhs, double rhs) {

--- a/doctest/parts/public/matchers/approx.h
+++ b/doctest/parts/public/matchers/approx.h
@@ -32,6 +32,16 @@ struct DOCTEST_INTERFACE Approx {
     }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
+    Approx &margin(double newMargin);
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template <typename T>
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type margin(const T &newMargin) {
+        m_margin = static_cast<double>(newMargin);
+        return *this;
+    }
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
     Approx &scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
@@ -80,6 +90,7 @@ struct DOCTEST_INTERFACE Approx {
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     double m_epsilon;
+    double m_margin;
     double m_scale;
     double m_value;
 };

--- a/examples/all_features/coverage_maxout.cpp
+++ b/examples/all_features/coverage_maxout.cpp
@@ -87,6 +87,7 @@ TEST_CASE("exercising tricky code paths of doctest") {
 
     Approx a(5);
     a.scale(4);
+    a.margin(0.1);
     const Approx b = a(7);
 
     CHECK(b == 7);


### PR DESCRIPTION
## Description
Add Catch2-style `Approx::margin()` for absolute floating-point tolerance.

## GitHub Issue
Closes #389

## Type
- [x] Feature addition

## Notes
Tooling helped with scaffolding; comparison behavior matches the issue ask.

## Checklist
- [x] Targets `dev`
- [x] Parts + reassembled header
