### PR TITLE
Android ADB emulator compatibility for the ARM architecture.

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -36,7 +36,7 @@ if("${spec}" MATCHES .)
 endif()
 
 execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-cases
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-cases --no-colors
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"
@@ -74,6 +74,9 @@ foreach(line ${output})
       )
     endif()
 
+    # Normalize line endings: adb shell (and pty-backed executors) can emit CRLF,
+    # which would otherwise leave a trailing \r on each parsed test name.
+    string(REPLACE "\r" "" output "${output}")
     string(REPLACE "\n" ";" labeloutput "${labeloutput}")
     foreach(labelline ${labeloutput})
       if("${labelline}" STREQUAL "===============================================================================" OR "${labelline}" MATCHES [==[^\[doctest\] ]==])


### PR DESCRIPTION
* Added option to disable colors in test case listing for robust parsing.
* Removed the excessive `\r` to normalize the output on adb.

## Description

The test builds were failing for me for the 64-bit ARM architectures, cause of invalid generated `_tests-*.cmake.cmake` population. The issue was arising on emulated ARM only (x86_64 worked fine) and may be connected to some inner workings of the emulation layer.

The following changes are fixing the issue and are tested to do so in production code.

Thank you for the tool!