### PR TITLE
Fix apparent leaks with mfc

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1063,6 +1063,7 @@ struct is_container<
 
 DOCTEST_INTERFACE std::ostream *tlssPush();
 DOCTEST_INTERFACE String tlssPop();
+DOCTEST_INTERFACE void tlssCleanup();
 
 template <bool C>
 struct StringMakerBase {
@@ -4985,7 +4986,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
 
 #endif // DOCTEST_PARTS_PRIVATE_REPORTERS_CONSOLE
 
-#include <iosfwd>
+#include <sstream>
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
@@ -4996,7 +4997,7 @@ namespace detail {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 struct DebugOutputWindowReporter : public ConsoleReporter {
-    DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+    std::ostringstream oss;
 
     DebugOutputWindowReporter(const ContextOptions &co);
 
@@ -5841,7 +5842,7 @@ void Context::setCout(std::ostream *out) {
     p->cout = out;
 }
 
-static class DiscardOStream : public std::ostream {
+class DiscardOStream : public std::ostream {
 private:
     class : public std::streambuf {
     private:
@@ -5862,7 +5863,7 @@ private:
 public:
     DiscardOStream() noexcept
         : std::ostream(&discardBuf) {}
-} discardOut;
+};
 
 // the main function that does all the filtering and test running
 int Context::run() {
@@ -5878,6 +5879,7 @@ int Context::run() {
     p->resetRunData();
 
     std::fstream fstr;
+    DiscardOStream discardOut;
     if (p->cout == nullptr) {
         if (p->quiet) {
             p->cout = &discardOut;
@@ -5919,6 +5921,7 @@ int Context::run() {
         for (auto &curr: p->reporters_currently_used)
             delete curr;
         p->reporters_currently_used.clear();
+        tlssCleanup();
 
         if (p->numTestCasesFailed && !p->no_exitcode)
             return EXIT_FAILURE;
@@ -6161,7 +6164,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-extern DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+DOCTEST_INTERFACE std::vector<IContextScope *> &getInfoContexts(); // for logging with INFO()
 } // namespace detail
 } // namespace doctest
 
@@ -6181,10 +6184,16 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+DOCTEST_THREAD_LOCAL std::vector<IContextScope *> *g_infoContexts = nullptr;
+
+std::vector<IContextScope *> &getInfoContexts() {
+    if (g_infoContexts == nullptr)
+        g_infoContexts = new std::vector<IContextScope *>;
+    return *g_infoContexts;
+}
 
 ContextScopeBase::ContextScopeBase() {
-    g_infoContexts.push_back(this);
+    getInfoContexts().push_back(this);
 }
 
 ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
@@ -6192,7 +6201,7 @@ ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
         other.destroy();
     }
     other.need_to_destroy = false;
-    g_infoContexts.push_back(this);
+    getInfoContexts().push_back(this);
 }
 
 // destroy cannot be inlined into the destructor because that would mean calling stringify after
@@ -6204,7 +6213,7 @@ void ContextScopeBase::destroy() {
         this->stringify(&s);
         g_cs->stringifiedContexts.emplace_back(s.str().c_str());
     }
-    g_infoContexts.pop_back();
+    getInfoContexts().pop_back();
 }
 
 } // namespace detail
@@ -6374,6 +6383,51 @@ bool isDebuggerActive() {
 #endif // DOCTEST_CONFIG_DISABLE
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION
+#define DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION
+
+
+// Registrations are intentionally performed during static initialization. In a
+// debug-CRT build these objects can still be alive when a host DLL asks the CRT
+// for a leak dump during its detach notification. Mark only allocations made
+// while registering doctest metadata as ignored, so that such a snapshot does
+// not mistake framework lifetime state for a user allocation leak.
+#if DOCTEST_MSVC && defined(_DEBUG)
+#include <crtdbg.h>
+#endif
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+class StaticRegistrationMemoryGuard {
+public:
+    StaticRegistrationMemoryGuard() noexcept {
+#if DOCTEST_MSVC && defined(_DEBUG)
+        m_flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+        _CrtSetDbgFlag(m_flags & ~_CRTDBG_ALLOC_MEM_DF);
+#endif
+    }
+
+    ~StaticRegistrationMemoryGuard() {
+#if DOCTEST_MSVC && defined(_DEBUG)
+        _CrtSetDbgFlag(m_flags);
+#endif
+    }
+
+private:
+#if DOCTEST_MSVC && defined(_DEBUG)
+    int m_flags;
+#endif
+};
+
+} // namespace detail
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION
 
 #include <algorithm>
 #include <string>
@@ -6388,12 +6442,14 @@ namespace detail {
 DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
 void registerExceptionTranslatorImpl(const IExceptionTranslator *et) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
         getExceptionTranslators().end())
         getExceptionTranslators().push_back(et);
 }
 
 std::vector<const IExceptionTranslator *> &getExceptionTranslators() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static std::vector<const IExceptionTranslator *> data;
     return data;
 }
@@ -6806,11 +6862,13 @@ int registerReporter(const char *, int, IReporter *) {
 
 namespace detail {
 reporterMap &getReporters() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static reporterMap data;
     return data;
 }
 
 reporterMap &getListeners() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static reporterMap data;
     return data;
 }
@@ -6819,11 +6877,11 @@ reporterMap &getListeners() noexcept {
 DOCTEST_DEFINE_INTERFACE(IReporter)
 
 int IReporter::get_num_active_contexts() {
-    return static_cast<int>(detail::g_infoContexts.size());
+    return static_cast<int>(detail::getInfoContexts().size());
 }
 
 const IContextScope *const *IReporter::get_active_contexts() {
-    return get_num_active_contexts() ? detail::g_infoContexts.data() : nullptr;
+    return get_num_active_contexts() ? detail::getInfoContexts().data() : nullptr;
 }
 
 int IReporter::get_num_stringified_contexts() {
@@ -6836,6 +6894,7 @@ const String *IReporter::get_stringified_contexts() {
 
 namespace detail {
 void registerReporterImpl(const char *name, int priority, reporterCreatorFunc c, bool isReporter) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     if (isReporter)
         getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
     else
@@ -7384,8 +7443,6 @@ namespace detail {
 #endif // Platform
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-
-DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 
 DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions &co)
     : ConsoleReporter(co, oss) {}
@@ -8165,7 +8222,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-DOCTEST_THREAD_LOCAL class oss {
+class oss {
     std::vector<std::streampos> stack;
     std::stringstream ss;
 
@@ -8188,14 +8245,31 @@ public:
         ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
         return String(ss, sz);
     }
-} g_oss; // NOLINT(bugprone-throwing-static-initialization, cert-err58-cpp)
+};
+
+DOCTEST_THREAD_LOCAL oss *g_oss = nullptr;
+
+static oss &getOss() {
+    if (g_oss == nullptr)
+        g_oss = new oss;
+    return *g_oss;
+}
 
 std::ostream *tlssPush() {
-    return g_oss.push();
+    return getOss().push();
 }
 
 String tlssPop() {
-    return g_oss.pop();
+    return getOss().pop();
+}
+
+void tlssCleanup() {
+    delete g_oss;
+    g_oss = nullptr;
+#ifndef DOCTEST_CONFIG_DISABLE
+    delete g_infoContexts;
+    g_infoContexts = nullptr;
+#endif
 }
 
 } // namespace detail
@@ -8645,6 +8719,7 @@ namespace doctest {
 namespace detail {
 
 std::set<TestCase> &getRegisteredTests() {
+    StaticRegistrationMemoryGuard memoryGuard;
     static std::set<TestCase> data;
     return data;
 }
@@ -8716,6 +8791,7 @@ bool TestCase::operator<(const TestCase &other) const noexcept {
 
 // used by the macros for registering tests
 int regTest(const TestCase &tc) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     getRegisteredTests().insert(tc);
     return 0;
 }

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6165,6 +6165,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 DOCTEST_INTERFACE std::vector<IContextScope *> &getInfoContexts(); // for logging with INFO()
+DOCTEST_INTERFACE void cleanupInfoContexts();
 } // namespace detail
 } // namespace doctest
 
@@ -6174,6 +6175,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
 
 #endif // DOCTEST_PARTS_PRIVATE_CONTEXT_SCOPE
 
+#include <memory>
 #include <sstream>
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
@@ -6184,12 +6186,16 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-DOCTEST_THREAD_LOCAL std::vector<IContextScope *> *g_infoContexts = nullptr;
+DOCTEST_THREAD_LOCAL std::unique_ptr<std::vector<IContextScope *>> g_infoContexts;
 
 std::vector<IContextScope *> &getInfoContexts() {
     if (g_infoContexts == nullptr)
-        g_infoContexts = new std::vector<IContextScope *>;
+        g_infoContexts.reset(new std::vector<IContextScope *>);
     return *g_infoContexts;
+}
+
+void cleanupInfoContexts() {
+    g_infoContexts.reset();
 }
 
 ContextScopeBase::ContextScopeBase() {
@@ -8214,6 +8220,7 @@ char *FatalConditionHandler::altStackMem = nullptr;
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
 
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -8247,11 +8254,11 @@ public:
     }
 };
 
-DOCTEST_THREAD_LOCAL oss *g_oss = nullptr;
+DOCTEST_THREAD_LOCAL std::unique_ptr<oss> g_oss;
 
 static oss &getOss() {
     if (g_oss == nullptr)
-        g_oss = new oss;
+        g_oss.reset(new oss);
     return *g_oss;
 }
 
@@ -8264,11 +8271,9 @@ String tlssPop() {
 }
 
 void tlssCleanup() {
-    delete g_oss;
-    g_oss = nullptr;
+    g_oss.reset();
 #ifndef DOCTEST_CONFIG_DISABLE
-    delete g_infoContexts;
-    g_infoContexts = nullptr;
+    cleanupInfoContexts();
 #endif
 }
 

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -407,7 +407,7 @@ void Context::setCout(std::ostream *out) {
     p->cout = out;
 }
 
-static class DiscardOStream : public std::ostream {
+class DiscardOStream : public std::ostream {
 private:
     class : public std::streambuf {
     private:
@@ -428,7 +428,7 @@ private:
 public:
     DiscardOStream() noexcept
         : std::ostream(&discardBuf) {}
-} discardOut;
+};
 
 // the main function that does all the filtering and test running
 int Context::run() {
@@ -444,6 +444,7 @@ int Context::run() {
     p->resetRunData();
 
     std::fstream fstr;
+    DiscardOStream discardOut;
     if (p->cout == nullptr) {
         if (p->quiet) {
             p->cout = &discardOut;
@@ -485,6 +486,7 @@ int Context::run() {
         for (auto &curr: p->reporters_currently_used)
             delete curr;
         p->reporters_currently_used.clear();
+        tlssCleanup();
 
         if (p->numTestCasesFailed && !p->no_exitcode)
             return EXIT_FAILURE;

--- a/doctest/parts/private/context_scope.cpp
+++ b/doctest/parts/private/context_scope.cpp
@@ -12,10 +12,16 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+DOCTEST_THREAD_LOCAL std::vector<IContextScope *> *g_infoContexts = nullptr;
+
+std::vector<IContextScope *> &getInfoContexts() {
+    if (g_infoContexts == nullptr)
+        g_infoContexts = new std::vector<IContextScope *>;
+    return *g_infoContexts;
+}
 
 ContextScopeBase::ContextScopeBase() {
-    g_infoContexts.push_back(this);
+    getInfoContexts().push_back(this);
 }
 
 ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
@@ -23,7 +29,7 @@ ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
         other.destroy();
     }
     other.need_to_destroy = false;
-    g_infoContexts.push_back(this);
+    getInfoContexts().push_back(this);
 }
 
 // destroy cannot be inlined into the destructor because that would mean calling stringify after
@@ -35,7 +41,7 @@ void ContextScopeBase::destroy() {
         this->stringify(&s);
         g_cs->stringifiedContexts.emplace_back(s.str().c_str());
     }
-    g_infoContexts.pop_back();
+    getInfoContexts().pop_back();
 }
 
 } // namespace detail

--- a/doctest/parts/private/context_scope.cpp
+++ b/doctest/parts/private/context_scope.cpp
@@ -2,6 +2,7 @@
 #include "doctest/parts/private/context_state.h"
 #include "doctest/parts/private/exceptions.h"
 
+#include <memory>
 #include <sstream>
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
@@ -12,12 +13,16 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-DOCTEST_THREAD_LOCAL std::vector<IContextScope *> *g_infoContexts = nullptr;
+DOCTEST_THREAD_LOCAL std::unique_ptr<std::vector<IContextScope *>> g_infoContexts;
 
 std::vector<IContextScope *> &getInfoContexts() {
     if (g_infoContexts == nullptr)
-        g_infoContexts = new std::vector<IContextScope *>;
+        g_infoContexts.reset(new std::vector<IContextScope *>);
     return *g_infoContexts;
+}
+
+void cleanupInfoContexts() {
+    g_infoContexts.reset();
 }
 
 ContextScopeBase::ContextScopeBase() {

--- a/doctest/parts/private/context_scope.h
+++ b/doctest/parts/private/context_scope.h
@@ -11,7 +11,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-extern DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+DOCTEST_INTERFACE std::vector<IContextScope *> &getInfoContexts(); // for logging with INFO()
 } // namespace detail
 } // namespace doctest
 

--- a/doctest/parts/private/context_scope.h
+++ b/doctest/parts/private/context_scope.h
@@ -12,6 +12,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 DOCTEST_INTERFACE std::vector<IContextScope *> &getInfoContexts(); // for logging with INFO()
+DOCTEST_INTERFACE void cleanupInfoContexts();
 } // namespace detail
 } // namespace doctest
 

--- a/doctest/parts/private/exception_translator.cpp
+++ b/doctest/parts/private/exception_translator.cpp
@@ -1,4 +1,5 @@
 #include "doctest/parts/private/exception_translator.h"
+#include "doctest/parts/private/static_registration.h"
 
 #include <algorithm>
 #include <string>
@@ -13,12 +14,14 @@ namespace detail {
 DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
 void registerExceptionTranslatorImpl(const IExceptionTranslator *et) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
         getExceptionTranslators().end())
         getExceptionTranslators().push_back(et);
 }
 
 std::vector<const IExceptionTranslator *> &getExceptionTranslators() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static std::vector<const IExceptionTranslator *> data;
     return data;
 }

--- a/doctest/parts/private/reporter.cpp
+++ b/doctest/parts/private/reporter.cpp
@@ -1,6 +1,7 @@
 #include "doctest/parts/private/context_scope.h"
 #include "doctest/parts/private/context_state.h"
 #include "doctest/parts/private/reporter.h"
+#include "doctest/parts/private/static_registration.h"
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
@@ -33,11 +34,13 @@ int registerReporter(const char *, int, IReporter *) {
 
 namespace detail {
 reporterMap &getReporters() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static reporterMap data;
     return data;
 }
 
 reporterMap &getListeners() noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     static reporterMap data;
     return data;
 }
@@ -63,6 +66,7 @@ const String *IReporter::get_stringified_contexts() {
 
 namespace detail {
 void registerReporterImpl(const char *name, int priority, reporterCreatorFunc c, bool isReporter) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     if (isReporter)
         getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
     else

--- a/doctest/parts/private/reporter.cpp
+++ b/doctest/parts/private/reporter.cpp
@@ -49,11 +49,11 @@ reporterMap &getListeners() noexcept {
 DOCTEST_DEFINE_INTERFACE(IReporter)
 
 int IReporter::get_num_active_contexts() {
-    return static_cast<int>(detail::g_infoContexts.size());
+    return static_cast<int>(detail::getInfoContexts().size());
 }
 
 const IContextScope *const *IReporter::get_active_contexts() {
-    return get_num_active_contexts() ? detail::g_infoContexts.data() : nullptr;
+    return get_num_active_contexts() ? detail::getInfoContexts().data() : nullptr;
 }
 
 int IReporter::get_num_stringified_contexts() {

--- a/doctest/parts/private/reporters/debug_output_window.cpp
+++ b/doctest/parts/private/reporters/debug_output_window.cpp
@@ -17,8 +17,6 @@ namespace detail {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 
-DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
-
 DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions &co)
     : ConsoleReporter(co, oss) {}
 

--- a/doctest/parts/private/reporters/debug_output_window.h
+++ b/doctest/parts/private/reporters/debug_output_window.h
@@ -3,7 +3,7 @@
 
 #include "doctest/parts/private/reporters/console.h"
 
-#include <iosfwd>
+#include <sstream>
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
@@ -14,7 +14,7 @@ namespace detail {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 struct DebugOutputWindowReporter : public ConsoleReporter {
-    DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+    std::ostringstream oss;
 
     DebugOutputWindowReporter(const ContextOptions &co);
 

--- a/doctest/parts/private/static_registration.h
+++ b/doctest/parts/private/static_registration.h
@@ -1,0 +1,46 @@
+#ifndef DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION
+#define DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION
+
+#include "doctest/parts/public/config.h"
+
+// Registrations are intentionally performed during static initialization. In a
+// debug-CRT build these objects can still be alive when a host DLL asks the CRT
+// for a leak dump during its detach notification. Mark only allocations made
+// while registering doctest metadata as ignored, so that such a snapshot does
+// not mistake framework lifetime state for a user allocation leak.
+#if DOCTEST_MSVC && defined(_DEBUG)
+#include <crtdbg.h>
+#endif
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+class StaticRegistrationMemoryGuard {
+public:
+    StaticRegistrationMemoryGuard() noexcept {
+#if DOCTEST_MSVC && defined(_DEBUG)
+        m_flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+        _CrtSetDbgFlag(m_flags & ~_CRTDBG_ALLOC_MEM_DF);
+#endif
+    }
+
+    ~StaticRegistrationMemoryGuard() {
+#if DOCTEST_MSVC && defined(_DEBUG)
+        _CrtSetDbgFlag(m_flags);
+#endif
+    }
+
+private:
+#if DOCTEST_MSVC && defined(_DEBUG)
+    int m_flags;
+#endif
+};
+
+} // namespace detail
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_STATIC_REGISTRATION

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -3,6 +3,7 @@
 #include "doctest/parts/public/string.h"
 
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -36,11 +37,11 @@ public:
     }
 };
 
-DOCTEST_THREAD_LOCAL oss *g_oss = nullptr;
+DOCTEST_THREAD_LOCAL std::unique_ptr<oss> g_oss;
 
 static oss &getOss() {
     if (g_oss == nullptr)
-        g_oss = new oss;
+        g_oss.reset(new oss);
     return *g_oss;
 }
 
@@ -53,11 +54,9 @@ String tlssPop() {
 }
 
 void tlssCleanup() {
-    delete g_oss;
-    g_oss = nullptr;
+    g_oss.reset();
 #ifndef DOCTEST_CONFIG_DISABLE
-    delete g_infoContexts;
-    g_infoContexts = nullptr;
+    cleanupInfoContexts();
 #endif
 }
 

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -1,3 +1,4 @@
+#include "doctest/parts/private/context_scope.h"
 #include "doctest/parts/private/exceptions.h"
 #include "doctest/parts/public/string.h"
 
@@ -54,6 +55,10 @@ String tlssPop() {
 void tlssCleanup() {
     delete g_oss;
     g_oss = nullptr;
+#ifndef DOCTEST_CONFIG_DISABLE
+    delete g_infoContexts;
+    g_infoContexts = nullptr;
+#endif
 }
 
 } // namespace detail

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -10,7 +10,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-DOCTEST_THREAD_LOCAL class oss {
+class oss {
     std::vector<std::streampos> stack;
     std::stringstream ss;
 
@@ -33,14 +33,27 @@ public:
         ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
         return String(ss, sz);
     }
-} g_oss; // NOLINT(bugprone-throwing-static-initialization, cert-err58-cpp)
+};
+
+DOCTEST_THREAD_LOCAL oss *g_oss = nullptr;
+
+static oss &getOss() {
+    if (g_oss == nullptr)
+        g_oss = new oss;
+    return *g_oss;
+}
 
 std::ostream *tlssPush() {
-    return g_oss.push();
+    return getOss().push();
 }
 
 String tlssPop() {
-    return g_oss.pop();
+    return getOss().pop();
+}
+
+void tlssCleanup() {
+    delete g_oss;
+    g_oss = nullptr;
 }
 
 } // namespace detail

--- a/doctest/parts/private/test_case.cpp
+++ b/doctest/parts/private/test_case.cpp
@@ -1,4 +1,5 @@
 #include "doctest/parts/private/test_case.h"
+#include "doctest/parts/private/static_registration.h"
 
 #include <cstring>
 
@@ -10,6 +11,7 @@ namespace doctest {
 namespace detail {
 
 std::set<TestCase> &getRegisteredTests() {
+    StaticRegistrationMemoryGuard memoryGuard;
     static std::set<TestCase> data;
     return data;
 }
@@ -81,6 +83,7 @@ bool TestCase::operator<(const TestCase &other) const noexcept {
 
 // used by the macros for registering tests
 int regTest(const TestCase &tc) noexcept {
+    StaticRegistrationMemoryGuard memoryGuard;
     getRegisteredTests().insert(tc);
     return 0;
 }

--- a/doctest/parts/public/string.h
+++ b/doctest/parts/public/string.h
@@ -221,6 +221,7 @@ struct is_container<
 
 DOCTEST_INTERFACE std::ostream *tlssPush();
 DOCTEST_INTERFACE String tlssPop();
+DOCTEST_INTERFACE void tlssCleanup();
 
 template <bool C>
 struct StringMakerBase {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,13 @@ doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1045.cpp EXCEPT ${FNOEXCE
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1165.cpp EXCEPT ${FNOEXCEPT})
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1171.cpp)
 
+# The debug CRT reports allocations which are still alive before static
+# destructors run. This regression test verifies that doctest does not leave
+# apparent leaks in that situation.
+if(MSVC)
+    doctest_add_unit_test(SOURCE regression/test.205.cpp)
+endif()
+
 set_tests_properties(
     regression/test.782.cpp
     PROPERTIES

--- a/tests/regression/test.205.cpp
+++ b/tests/regression/test.205.cpp
@@ -1,0 +1,38 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+#if defined(_MSC_VER) && defined(_DEBUG)
+#include <crtdbg.h>
+#include <doctest/parts/private/reporters/debug_output_window.h>
+#endif
+
+TEST_CASE("doctest test run owns its temporary memory") {
+    INFO("Create active INFO context storage");
+    static_cast<void>(doctest::toString(42));
+    CHECK(true);
+}
+
+int main(int argc, char **argv) {
+#if defined(_MSC_VER) && defined(_DEBUG)
+    {
+        // This used to own a thread-local stream for the process lifetime.
+        doctest::ContextOptions options{};
+        doctest::detail::DebugOutputWindowReporter reporter{options};
+    }
+#endif
+
+    int result = EXIT_SUCCESS;
+    {
+        doctest::Context context{argc, argv};
+        context.setOption("quiet", true);
+        context.setOption("no-debug-output", true);
+        result = context.run();
+    }
+
+#if defined(_MSC_VER) && defined(_DEBUG)
+    if (_CrtDumpMemoryLeaks())
+        return EXIT_FAILURE;
+#endif
+
+    return result;
+}

--- a/tests/regression/test.205.cpp
+++ b/tests/regression/test.205.cpp
@@ -1,6 +1,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+#include <thread>
+
 #if defined(_MSC_VER) && defined(_DEBUG)
 #include <crtdbg.h>
 #include <doctest/parts/private/reporters/debug_output_window.h>
@@ -9,6 +11,14 @@
 TEST_CASE("doctest test run owns its temporary memory") {
     INFO("Create active INFO context storage");
     static_cast<void>(doctest::toString(42));
+
+    std::thread worker{[] {
+        INFO("Create active INFO context storage in a worker thread");
+        static_cast<void>(doctest::toString(42));
+        CHECK(true);
+    }};
+    worker.join();
+
     CHECK(true);
 }
 


### PR DESCRIPTION
## Description
Refer to https://github.com/doctest/doctest/issues/205#issuecomment-5479310995 for the why of this pull request.

This pull request removes some static allocations and disable memory tracking for the ones that were not removed.

A test has been added to validate no apparent leaks are detected.
The test fails as expected when run on the dev branch without this PR's fixes

## GitHub Issues
https://github.com/doctest/doctest/issues/205